### PR TITLE
Target CK 1.0.0rc2+rdkafka 1.0.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,15 +18,15 @@ The `Unreleased` section name is replaced by the expected version of next releas
 
 ### Changed
 
-- Updated to target `Confluent.Kafka 1.0.0-RC2` (which references `librdkafka.redist 1.0.0`)
-- Pins `rdkafka` and `Confluent.Kafka` dependencies to specific known good versions as above.
+- Updated to target `Confluent.Kafka 1.0.0-RC2` (which references `librdkafka.redist 1.0.0`) [#23](https://github.com/jet/Jet.ConfluentKafka.FSharp/pull/23)
+- Pins `rdkafka` and `Confluent.Kafka` dependencies to specific known good versions as above [#22](https://github.com/jet/Jet.ConfluentKafka.FSharp/issues/22)
 
 <a name="1.0.0-preview2"></a>
 ## [1.0.0-preview2] - 2019-03-26
 
 ### Changed
 
-- Updated to target `Confluent.Kafka 1.0.0-RC1` (triggered relatively minor changes internally due to sane API fixes, does not update to rdkafka 1.0.0, still `1.0.0-RC9`)
+- Updated to target `Confluent.Kafka 1.0.0-RC1` (triggered relatively minor changes internally due to sane API fixes, does not update to rdkafka 1.0.0, still `1.0.0-RC9`) [#21](https://github.com/jet/Jet.ConfluentKafka.FSharp/pull/21)
 
 <a name="1.0.0-preview1"></a>
 ## [1.0.0-preview1] - 2019-03-05

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,12 +13,20 @@ The `Unreleased` section name is replaced by the expected version of next releas
 ### Removed
 ### Fixed
 
+<a name="1.0.0-rc1"></a>
+## [1.0.0-rc1] - 2019-03-27
+
+### Changed
+
+- Updated to target `Confluent.Kafka 1.0.0-RC2` (which references `librdkafka.redist 1.0.0`)
+- Pins `rdkafka` and `Confluent.Kafka` dependencies to specific known good versions as above.
+
 <a name="1.0.0-preview2"></a>
 ## [1.0.0-preview2] - 2019-03-26
 
 ### Changed
 
-- Updated to target `Confluent.Kafka 1.0.0-RC1` (triggered relatively minor changes internally due to sane API fixes, does not update rdkafka, which is still `0.9.6-PRE2`)
+- Updated to target `Confluent.Kafka 1.0.0-RC1` (triggered relatively minor changes internally due to sane API fixes, does not update to rdkafka 1.0.0, still `1.0.0-RC9`)
 
 <a name="1.0.0-preview1"></a>
 ## [1.0.0-preview1] - 2019-03-05

--- a/src/Jet.ConfluentKafka.FSharp/Jet.ConfluentKafka.FSharp.fsproj
+++ b/src/Jet.ConfluentKafka.FSharp/Jet.ConfluentKafka.FSharp.fsproj
@@ -16,13 +16,14 @@
 
   <ItemGroup>
     <PackageReference Include="Microsoft.SourceLink.GitHub" Version="1.0.0-beta2-18618-05" PrivateAssets="All"/>
-    <PackageReference Include="MinVer" Version="1.0.0-rc.1" PrivateAssets="All" />
+    <PackageReference Include="MinVer" Version="1.0.0" PrivateAssets="All" />
 
     <PackageReference Include="FSharp.Core" Version="3.1.2.5" Condition=" '$(TargetFramework)' != 'netstandard2.0' " />
     <PackageReference Include="FSharp.Core" Version="4.3.4" Condition=" '$(TargetFramework)' == 'netstandard2.0' " />
 
     <PackageReference Include="Newtonsoft.Json" Version="11.0.2" />
-    <PackageReference Include="Confluent.Kafka" Version="1.0.0-RC1" />
+    <PackageReference Include="Confluent.Kafka" Version="[1.0.0-RC2]" />
+    <PackageReference Include="librdkafka.redist" Version="[1.0.0]" />
     <PackageReference Include="Serilog" Version="2.7.1" />
   </ItemGroup>
 


### PR DESCRIPTION
Update to use `Confluent.Kafka 1.0.0-RC2`, which targets `librdkafka 1.0.0`

Also addresses #22, pinning to specific tested versions for consistency