### PR TITLE
Target Confluent.Kafka 1.0.0-RC3; use CompressionType

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,13 @@ The `Unreleased` section name is replaced by the expected version of next releas
 ### Removed
 ### Fixed
 
+<a name="1.0.0-rc2"></a>
+## [1.0.0-rc2] - 2019-04-02
+
+### Changed
+
+- Updated to target `Confluent.Kafka 1.0.0-RC3` [#24](https://github.com/jet/Jet.ConfluentKafka.FSharp/pull/24)
+
 <a name="1.0.0-rc1"></a>
 ## [1.0.0-rc1] - 2019-03-27
 
@@ -43,7 +50,8 @@ The `Unreleased` section name is replaced by the expected version of next releas
 
 (Stripped down repo for history purposes, see [`v0` branch](tree/v0) for implementation targeting `Confluent.Kafka` v `0.9.4`)
 
-[Unreleased]: https://github.com/jet/Jet.ConfluentKafka.FSharp/compare/1.0.0-rc1...HEAD
+[Unreleased]: https://github.com/jet/Jet.ConfluentKafka.FSharp/compare/1.0.0-rc2...HEAD
+[1.0.0-rc2]: https://github.com/jet/Jet.ConfluentKafka.FSharp/compare/1.0.0-rc1...1.0.0-rc2
 [1.0.0-rc1]: https://github.com/jet/Jet.ConfluentKafka.FSharp/compare/1.0.0-preview2...1.0.0-rc1
 [1.0.0-preview2]: https://github.com/jet/Jet.ConfluentKafka.FSharp/compare/1.0.0-preview1...1.0.0-preview2
 [1.0.0-preview1]: https://github.com/jet/Jet.ConfluentKafka.FSharp/compare/1.0.0-bare...1.0.0-preview1

--- a/src/Jet.ConfluentKafka.FSharp/Jet.ConfluentKafka.FSharp.fsproj
+++ b/src/Jet.ConfluentKafka.FSharp/Jet.ConfluentKafka.FSharp.fsproj
@@ -22,7 +22,7 @@
     <PackageReference Include="FSharp.Core" Version="4.3.4" Condition=" '$(TargetFramework)' == 'netstandard2.0' " />
 
     <PackageReference Include="Newtonsoft.Json" Version="11.0.2" />
-    <PackageReference Include="Confluent.Kafka" Version="[1.0.0-RC2]" />
+    <PackageReference Include="Confluent.Kafka" Version="[1.0.0-RC3]" />
     <PackageReference Include="librdkafka.redist" Version="[1.0.0]" />
     <PackageReference Include="Serilog" Version="2.7.1" />
   </ItemGroup>


### PR DESCRIPTION
- Update to CK1.0 RC3
- no underlying `rdkafka` updated associated with same
- use intrinsic `CompressionType` added in this release