### PR TITLE
Correctly handle config with empty debug flags

### DIFF
--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -1,3 +1,5 @@
+### 0.9.6 - 2019-04-19
+* Correctly handle config with empty debug flags
 ### 0.9.5 - 2018-08-14
 * Save offsets when using "streamBuffered" consumer
 ### 0.9.4 - 2018-08-14

--- a/src/Confluent.Kafka.FSharp/ConfluentKafka.fs
+++ b/src/Confluent.Kafka.FSharp/ConfluentKafka.fs
@@ -104,11 +104,16 @@ module Config =
 
     let configs configs map = List.fold (fun m (k, v) -> config k v m) map configs
     let debug (debugFlag: seq<DebugFlags.DebugFlag>) configs =
-      let str =
-        debugFlag
-        |> Seq.map enumToString
-        |> String.concat ","
-      config "debug" str configs
+        if Seq.isEmpty debugFlag then
+            // Confluent throws an error if the debug flags array is empty,
+            // so in that case we don't set it.
+            configs 
+        else
+            let str =
+                debugFlag
+                |> Seq.map enumToString
+                |> String.concat ","
+            config "debug" str configs
 
     //
     // Strong typed


### PR DESCRIPTION
Confluent throws an error if the debug flags array is empty. This PR updates `Config.debug` to ignore debug flags if the list is empty.