### PR TITLE
Pre 1.0 API cleanup

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,7 +9,14 @@ The `Unreleased` section name is replaced by the expected version of next releas
 ## [Unreleased]
 
 ### Added
+
+- each configuration DSL now has a `customize` function to admit post-processing after defaults and `custom` have taken effect [#29](https://github.com/jet/Jet.ConfluentKafka.FSharp/pull/29)
+- Producer/Consumer both have an `Inner` to enable custom logic [#29](https://github.com/jet/Jet.ConfluentKafka.FSharp/pull/29)
+
 ### Changed
+
+- default auto-commit interval dropped from 10s to 5s (which is the `Confluent.Kafka` default) [#29](https://github.com/jet/Jet.ConfluentKafka.FSharp/pull/29)
+
 ### Removed
 ### Fixed
 
@@ -18,7 +25,7 @@ The `Unreleased` section name is replaced by the expected version of next releas
 
 ### Fixed
 
-# Make custom parameters in consumer config a seq once again [#28](https://github.com/jet/Jet.ConfluentKafka.FSharp/pull/28) [@szer](https://github.com/Szer)
+- Make custom parameters in consumer config a seq once again [#28](https://github.com/jet/Jet.ConfluentKafka.FSharp/pull/28) [@szer](https://github.com/Szer)
 
 <a name="1.0.0-rc7"></a>
 ## [1.0.0-rc7] - 2019-05-16

--- a/src/Jet.ConfluentKafka.FSharp/ConfluentKafka.fs
+++ b/src/Jet.ConfluentKafka.FSharp/ConfluentKafka.fs
@@ -89,7 +89,7 @@ type KafkaProducer private (log, inner : IProducer<string, string>, topic : stri
     static member Create(log : ILogger, config : KafkaProducerConfig, topic : string): KafkaProducer =
         if String.IsNullOrEmpty topic then nullArg "topic"
         log.Information("Producing... {broker} / {topic} compression={compression} maxInFlight={maxInFlight} acks={acks} lingerMs={linger}",
-            config.Broker, topic, config.Compression, config.MaxInFlight, config.Acks, config.Inner.LingerMs.Value)
+            config.Broker, topic, config.Compression, config.MaxInFlight, config.Acks, (let l = config.Inner.LingerMs in l.Value))
         let p =
             ProducerBuilder<string, string>(config.Inner)
                 .SetLogHandler(fun _p m -> log.Information("{message} level={level} name={name} facility={facility}", m.Message, m.Level, m.Name, m.Facility))


### PR DESCRIPTION
This is the result of a read-and-review as I'm using this in a client template. I've applied the following:

- _intentional minor breaking changes_ to remove arbitrary deviations from `Confluent.Kafka` defaults:
    - `offsetCommitInterval` - the frequency of commits of consumer offsets increases to 5s to align with CK default (was 10s for historical reasons)
    - `fetchMinBytes` default is now 1B (was 10B for historical reasons)
- adding information as to how the settings used relate to documented `Confluent.Kafka` default values
- removed egregious setting of CK Config values to `null`
- exposed an `Inner` on Producer/Consumer to enable custom client logic without having to fork
- F# syntax conventions - no egregious `val` usage, no curried `member`s