### PR TITLE
Split Batching impls out to own types; make defaults less surprising

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,7 +9,14 @@ The `Unreleased` section name is replaced by the expected version of next releas
 ## [Unreleased]
 
 ### Added
+
+- split batching behaviors out into `BatchedProducer`/`BatchedConsumer` [#30](https://github.com/jet/Jet.ConfluentKafka.FSharp/pull/30)
+
 ### Changed
+
+- default auto-commit interval dropped from 10s to 5s (which is the `Confluent.Kafka` default) [#30](https://github.com/jet/Jet.ConfluentKafka.FSharp/pull/30)
+- removed curried `member` Method arguments in `Start` methods
+
 ### Removed
 ### Fixed
 
@@ -24,6 +31,7 @@ The `Unreleased` section name is replaced by the expected version of next releas
 ### Changed
 
 - default auto-commit interval dropped from 10s to 5s (which is the `Confluent.Kafka` default) [#29](https://github.com/jet/Jet.ConfluentKafka.FSharp/pull/29)
+- default `fetchMinBytes` dropped from 10 to 1 (which is the `Confluent.Kafka` default) [#29](https://github.com/jet/Jet.ConfluentKafka.FSharp/pull/29)
 
 <a name="1.0.0-rc8"></a>
 ## [1.0.0-rc8] - 2019-05-21


### PR DESCRIPTION
Splits the Batch production logic into a separated types and changes some defaults in the interests of safety/reducing ambiguity:

- sets default `maxInFlightRequests` to `1` (instead of `1_000_000`), requiring opting in to the potentially reordering behavior implied by the default. Per Kafka, The Definitive Guide:

    > if guaranteeing order is critical, we recommend setting in.flight.requests.per.session=1 to make sure that while a batch of messages is retrying, additional messages will not be sent

- increases batch production linger from 10ms to 100ms (`Confluent.Kafka` default value, makes sense)

- provides a mechanism to avoid logging messages from the `InFlightMessageCounter`:

    ```
    .MinimumLevel.Override(Jet.ConfluentKafka.FSharp.Constants.messageCounterSourceContext, Serilog.Events.LogEventLevel.Warning )
    ```

*Contains intentionally breaking signature changes*