### PR TITLE
Split ParallelConsumer out to Propulsion+Propulsion.Kafka

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,9 @@ The `Unreleased` section name is replaced by the expected version of next releas
 
 ### Added
 ### Changed
+
+- Split reusable components of `ParallelConsumer` out into indepedent `Projection` and `Projection.Kafka` libraries [#34](https://github.com/jet/Jet.ConfluentKafka.FSharp/pull/34)
+
 ### Removed
 ### Fixed
 

--- a/Jet.ConfluentKafka.FSharp.sln
+++ b/Jet.ConfluentKafka.FSharp.sln
@@ -33,6 +33,10 @@ Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "src", "src", "{4670F7C4-A4F
 EndProject
 Project("{6EC3EE1D-3C4E-46DD-8F32-0CC8E7565705}") = "Jet.ConfluentKafka.FSharp", "src\Jet.ConfluentKafka.FSharp\Jet.ConfluentKafka.FSharp.fsproj", "{76802BE3-00C2-4B1D-96A2-95A3E2136DBE}"
 EndProject
+Project("{6EC3EE1D-3C4E-46DD-8F32-0CC8E7565705}") = "Propulsion", "src\Propulsion\Propulsion.fsproj", "{0F72360F-1C14-46E3-9A60-B6BF87BD726D}"
+EndProject
+Project("{6EC3EE1D-3C4E-46DD-8F32-0CC8E7565705}") = "Propulsion.Kafka", "src\Propulsion.Kafka\Propulsion.Kafka.fsproj", "{5F176C54-609B-4D2E-804B-3C1F60ADDAF4}"
+EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
 		Debug|Any CPU = Debug|Any CPU
@@ -47,6 +51,14 @@ Global
 		{76802BE3-00C2-4B1D-96A2-95A3E2136DBE}.Debug|Any CPU.Build.0 = Debug|Any CPU
 		{76802BE3-00C2-4B1D-96A2-95A3E2136DBE}.Release|Any CPU.ActiveCfg = Release|Any CPU
 		{76802BE3-00C2-4B1D-96A2-95A3E2136DBE}.Release|Any CPU.Build.0 = Release|Any CPU
+		{0F72360F-1C14-46E3-9A60-B6BF87BD726D}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{0F72360F-1C14-46E3-9A60-B6BF87BD726D}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{0F72360F-1C14-46E3-9A60-B6BF87BD726D}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{0F72360F-1C14-46E3-9A60-B6BF87BD726D}.Release|Any CPU.Build.0 = Release|Any CPU
+		{5F176C54-609B-4D2E-804B-3C1F60ADDAF4}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{5F176C54-609B-4D2E-804B-3C1F60ADDAF4}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{5F176C54-609B-4D2E-804B-3C1F60ADDAF4}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{5F176C54-609B-4D2E-804B-3C1F60ADDAF4}.Release|Any CPU.Build.0 = Release|Any CPU
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE
@@ -54,6 +66,8 @@ Global
 	GlobalSection(NestedProjects) = preSolution
 		{1D205901-2742-45EA-8255-E6322B49E3BB} = {302B09C4-7F38-4CF7-93B9-1B7A6035386E}
 		{76802BE3-00C2-4B1D-96A2-95A3E2136DBE} = {4670F7C4-A4FD-4E3F-B97C-99F9B3FC1898}
+		{0F72360F-1C14-46E3-9A60-B6BF87BD726D} = {4670F7C4-A4FD-4E3F-B97C-99F9B3FC1898}
+		{5F176C54-609B-4D2E-804B-3C1F60ADDAF4} = {4670F7C4-A4FD-4E3F-B97C-99F9B3FC1898}
 	EndGlobalSection
 	GlobalSection(ExtensibilityGlobals) = postSolution
 		SolutionGuid = {DF04AF73-7412-46E5-9CC8-15CB48E3139A}

--- a/src/Propulsion.Kafka/Infrastructure.fs
+++ b/src/Propulsion.Kafka/Infrastructure.fs
@@ -1,0 +1,31 @@
+namespace Propulsion.Kafka
+
+open System
+open System.Threading.Tasks
+
+[<AutoOpen>]
+module private AsyncHelpers =
+    type Async with
+        static member AwaitTaskCorrect (task : Task<'T>) : Async<'T> =
+            Async.FromContinuations <| fun (k,ek,_) ->
+                task.ContinueWith (fun (t:Task<'T>) ->
+                    if t.IsFaulted then
+                        let e = t.Exception
+                        if e.InnerExceptions.Count = 1 then ek e.InnerExceptions.[0]
+                        else ek e
+                    elif t.IsCanceled then ek (TaskCanceledException("Task wrapped with Async has been cancelled."))
+                    elif t.IsCompleted then k t.Result
+                    else ek(Exception "invalid Task state!"))
+                |> ignore
+
+        static member AwaitTaskCorrect (task : Task) : Async<unit> =
+            Async.FromContinuations <| fun (k,ek,_) ->
+                task.ContinueWith (fun (t:Task) ->
+                    if t.IsFaulted then
+                        let e = t.Exception
+                        if e.InnerExceptions.Count = 1 then ek e.InnerExceptions.[0]
+                        else ek e
+                    elif t.IsCanceled then ek (TaskCanceledException("Task wrapped with Async has been cancelled."))
+                    elif t.IsCompleted then k ()
+                    else ek(Exception "invalid Task state!"))
+                |> ignore

--- a/src/Propulsion.Kafka/Propulsion.Kafka.fsproj
+++ b/src/Propulsion.Kafka/Propulsion.Kafka.fsproj
@@ -12,7 +12,7 @@
 
   <ItemGroup>
     <Compile Include="Infrastructure.fs" />
-    <Compile Include="ConfluentKafka.fs" />
+    <Compile Include="KafkaPropulsion.fs" />
   </ItemGroup>
 
   <ItemGroup>
@@ -22,10 +22,12 @@
     <PackageReference Include="FSharp.Core" Version="3.1.2.5" Condition=" '$(TargetFramework)' == 'net461' " />
     <PackageReference Include="FSharp.Core" Version="4.3.4" Condition=" '$(TargetFramework)' != 'net461' " />
 
-    <PackageReference Include="Newtonsoft.Json" Version="11.0.2" />
-    <PackageReference Include="Confluent.Kafka" Version="[1.0.0]" />
-    <PackageReference Include="librdkafka.redist" Version="[1.0.0]" />
     <PackageReference Include="Serilog" Version="2.7.1" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <ProjectReference Include="..\Jet.ConfluentKafka.FSharp\Jet.ConfluentKafka.FSharp.fsproj" />
+    <ProjectReference Include="..\Propulsion\Propulsion.fsproj" />
   </ItemGroup>
 
 </Project>

--- a/src/Propulsion/Infrastructure.fs
+++ b/src/Propulsion/Infrastructure.fs
@@ -1,0 +1,37 @@
+namespace Propulsion
+
+open System
+open System.Threading.Tasks
+
+#if NET461
+module Array =
+    let takeWhile p = Seq.takeWhile p >> Array.ofSeq
+    let head = Seq.head
+#endif
+
+[<AutoOpen>]
+module private AsyncHelpers =
+    type Async with
+        static member AwaitTaskCorrect (task : Task<'T>) : Async<'T> =
+            Async.FromContinuations <| fun (k,ek,_) ->
+                task.ContinueWith (fun (t:Task<'T>) ->
+                    if t.IsFaulted then
+                        let e = t.Exception
+                        if e.InnerExceptions.Count = 1 then ek e.InnerExceptions.[0]
+                        else ek e
+                    elif t.IsCanceled then ek (TaskCanceledException("Task wrapped with Async has been cancelled."))
+                    elif t.IsCompleted then k t.Result
+                    else ek(Exception "invalid Task state!"))
+                |> ignore
+
+        static member AwaitTaskCorrect (task : Task) : Async<unit> =
+            Async.FromContinuations <| fun (k,ek,_) ->
+                task.ContinueWith (fun (t:Task) ->
+                    if t.IsFaulted then
+                        let e = t.Exception
+                        if e.InnerExceptions.Count = 1 then ek e.InnerExceptions.[0]
+                        else ek e
+                    elif t.IsCanceled then ek (TaskCanceledException("Task wrapped with Async has been cancelled."))
+                    elif t.IsCompleted then k ()
+                    else ek(Exception "invalid Task state!"))
+                |> ignore

--- a/src/Propulsion/Propulsion.fs
+++ b/src/Propulsion/Propulsion.fs
@@ -1,0 +1,126 @@
+﻿namespace Propulsion
+
+open Serilog
+open System
+open System.Collections.Concurrent
+open System.Collections.Generic
+open System.Diagnostics
+open System.Threading
+
+[<AutoOpen>]
+module Internal =
+
+    /// Gathers stats relating to how many items of a given partition have been observed
+    type PartitionStats() =
+        let partitions = Dictionary<int,int64>()
+        member __.Record(partitionId, ?weight) = 
+            let weight = defaultArg weight 1L
+            match partitions.TryGetValue partitionId with
+            | true, catCount -> partitions.[partitionId] <- catCount + weight
+            | false, _ -> partitions.[partitionId] <- weight
+        member __.Clear() = partitions.Clear()
+        member __.StatsDescending = partitions |> Seq.sortBy (fun x -> -x.Value) |> Seq.map (|KeyValue|)
+
+    /// Maintains a Stopwatch such that invoking will yield true at intervals defined by `period`
+    let intervalCheck (period : TimeSpan) =
+        let timer, max = Stopwatch.StartNew(), int64 period.TotalMilliseconds
+        fun () ->
+            let due = timer.ElapsedMilliseconds > max
+            if due then timer.Restart()
+            due
+
+/// Holds batches from the Ingestion pipe, feeding them continuously to the scheduler in an appropriate order
+module Submission =
+
+    /// Batch of work as passed from the Submitter to the Scheduler comprising messages with their associated checkpointing/completion callback
+    [<NoComparison; NoEquality>]
+    type SubmissionBatch<'M> = { partitionId : int; onCompletion: unit -> unit; messages: 'M [] }
+
+    /// Holds the queue for a given partition, together with a semaphore we use to ensure the number of in-flight batches per partition is constrained
+    [<NoComparison>]
+    type PartitionQueue<'B> = { submissions: SemaphoreSlim; queue : Queue<'B> } with
+        member __.Append(batch) = __.queue.Enqueue batch
+        static member Create(maxSubmits) = { submissions = new SemaphoreSlim(maxSubmits); queue = Queue(maxSubmits * 2) } 
+
+    /// Holds the stream of incoming batches, grouping by partition
+    /// Manages the submission of batches into the Scheduler in a fair manner
+    type SubmissionEngine<'M,'B>
+        (   log : ILogger, maxSubmitsPerPartition, mapBatch: (unit -> unit) -> SubmissionBatch<'M> -> 'B, submitBatch : 'B -> int, statsInterval, ?pumpInterval : TimeSpan,
+            ?tryCompactQueue) =
+        let pumpInterval = defaultArg pumpInterval (TimeSpan.FromMilliseconds 5.)
+        let incoming = new BlockingCollection<SubmissionBatch<'M>[]>(ConcurrentQueue())
+        let buffer = Dictionary<int,PartitionQueue<'B>>()
+        let mutable cycles, ingested, compacted = 0, 0, 0
+        let submittedBatches,submittedMessages = PartitionStats(), PartitionStats()
+        let dumpStats () =
+            let waiting = seq { for x in buffer do if x.Value.queue.Count <> 0 then yield x.Key, x.Value.queue.Count } |> Seq.sortBy (fun (_,snd) -> -snd)
+            log.Information("Submitter {cycles} cycles {ingested} accepted {compactions} compactions Holding {@waiting}", cycles, ingested, compacted, waiting)
+            log.Information(" Submitted Batches {@batches} Messages {@messages}", submittedBatches.StatsDescending, submittedMessages.StatsDescending)
+            ingested <- 0; compacted <- 0; cycles <- 0; submittedBatches.Clear(); submittedMessages.Clear()
+        let maybeLogStats =
+            let due = intervalCheck statsInterval
+            fun () ->
+                cycles <- cycles + 1
+                if due () then dumpStats ()
+        // Loop, submitting 0 or 1 item per partition per iteration to ensure
+        // - each partition has a controlled maximum number of entrants in the scheduler queue
+        // - a fair ordering of batch submissions
+        let propagate () =
+            let mutable more, worked = true, false
+            while more do
+                more <- false
+                for KeyValue(pi,pq) in buffer do
+                    if pq.queue.Count <> 0 then
+                        if pq.submissions.Wait(0) then
+                            worked <- true
+                            more <- true
+                            let count = submitBatch <| pq.queue.Dequeue()
+                            submittedBatches.Record(pi)
+                            submittedMessages.Record(pi, int64 count)
+            worked
+        /// Take one timeslice worth of ingestion and add to relevant partition queues
+        /// When ingested, we allow one propagation submission per partition
+        let ingest (partitionBatches : SubmissionBatch<'M>[]) =
+            for { partitionId = pid } as batch in partitionBatches do
+                let pq =
+                    match buffer.TryGetValue pid with
+                    | false, _ -> let t = PartitionQueue<_>.Create(maxSubmitsPerPartition) in buffer.[pid] <- t; t
+                    | true, pq -> pq
+                let mapped = mapBatch (fun () -> pq.submissions.Release() |> ignore) batch
+                pq.Append(mapped)
+            propagate()
+        /// We use timeslices where we're we've fully provisioned the scheduler to index any waiting Batches
+        let compact f =
+            let mutable worked = false
+            for KeyValue(_,pq) in buffer do
+                if f pq.queue then
+                    worked <- true
+            if worked then compacted <- compacted + 1; true
+            else false
+
+        /// Processing loop, continuously splitting `Submit`ted items into per-partition queues and ensuring enough items are provided to the Scheduler
+        member __.Pump() = async {
+            let! ct = Async.CancellationToken
+            while not ct.IsCancellationRequested do
+                let mutable items = Unchecked.defaultof<_>
+                let mutable propagated = false
+                if incoming.TryTake(&items, pumpInterval) then
+                    propagated <- ingest items
+                    while incoming.TryTake(&items) do
+                        if ingest items then propagated <- true
+                else propagated <- propagate()
+                match propagated, tryCompactQueue with
+                | false, None -> Thread.Sleep 2
+                | false, Some f when not (compact f) -> Thread.Sleep 2
+                | _ -> ()
+
+                maybeLogStats () }
+
+        /// Supplies a set of Batches for holding and forwarding to scheduler at the right time
+        member __.Ingest(items : SubmissionBatch<'M>[]) =
+            Interlocked.Increment(&ingested) |> ignore
+            incoming.Add items
+
+        /// Supplies an incoming Batch for holding and forwarding to scheduler at the right time
+        member __.Ingest(batch : SubmissionBatch<'M>) =
+            __.Ingest [| batch |]

--- a/src/Propulsion/Propulsion.fsproj
+++ b/src/Propulsion/Propulsion.fsproj
@@ -12,7 +12,7 @@
 
   <ItemGroup>
     <Compile Include="Infrastructure.fs" />
-    <Compile Include="ConfluentKafka.fs" />
+    <Compile Include="Propulsion.fs" />
   </ItemGroup>
 
   <ItemGroup>
@@ -22,9 +22,6 @@
     <PackageReference Include="FSharp.Core" Version="3.1.2.5" Condition=" '$(TargetFramework)' == 'net461' " />
     <PackageReference Include="FSharp.Core" Version="4.3.4" Condition=" '$(TargetFramework)' != 'net461' " />
 
-    <PackageReference Include="Newtonsoft.Json" Version="11.0.2" />
-    <PackageReference Include="Confluent.Kafka" Version="[1.0.0]" />
-    <PackageReference Include="librdkafka.redist" Version="[1.0.0]" />
     <PackageReference Include="Serilog" Version="2.7.1" />
   </ItemGroup>
 

--- a/tests/Jet.ConfluentKafka.FSharp.Integration/Jet.ConfluentKafka.FSharp.Integration.fsproj
+++ b/tests/Jet.ConfluentKafka.FSharp.Integration/Jet.ConfluentKafka.FSharp.Integration.fsproj
@@ -13,6 +13,7 @@
 
   <ItemGroup>
     <ProjectReference Include="..\..\src\Jet.ConfluentKafka.FSharp\Jet.ConfluentKafka.FSharp.fsproj" />
+    <ProjectReference Include="..\..\src\Propulsion.Kafka\Propulsion.Kafka.fsproj" />
   </ItemGroup>
 
   <ItemGroup>

--- a/tests/Jet.ConfluentKafka.FSharp.Integration/ParallelConsumerIntegration.fs
+++ b/tests/Jet.ConfluentKafka.FSharp.Integration/ParallelConsumerIntegration.fs
@@ -2,6 +2,7 @@
 
 open Jet.ConfluentKafka.FSharp
 open Newtonsoft.Json
+open Propulsion.Kafka
 open Serilog
 open Swensen.Unquote
 open System


### PR DESCRIPTION
In preparation for adding a StreamedConsumer, this PR:

- moves generic parallelism-related logic out of `Jet.ConfluentKafka.FSharp` into `Propulsion`
- moves `ParallelConsumer`'s implementation into `Propulsion.Kafka`