### PR TITLE
Add StreamsProducer + StreamsConsumer

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,9 @@ The `Unreleased` section name is replaced by the expected version of next releas
 ## [Unreleased]
 
 ### Added
+
+- Add `StreamsConsumer` and `StreamsProducer` [#35](https://github.com/jet/Jet.ConfluentKafka.FSharp/pull/35)
+
 ### Changed
 
 - Split reusable components of `ParallelConsumer` out into independent `Propulsion` and `Propulsion.Kafka` libraries [#34](https://github.com/jet/Jet.ConfluentKafka.FSharp/pull/34)

--- a/Jet.ConfluentKafka.FSharp.sln
+++ b/Jet.ConfluentKafka.FSharp.sln
@@ -37,6 +37,8 @@ Project("{6EC3EE1D-3C4E-46DD-8F32-0CC8E7565705}") = "Propulsion", "src\Propulsio
 EndProject
 Project("{6EC3EE1D-3C4E-46DD-8F32-0CC8E7565705}") = "Propulsion.Kafka", "src\Propulsion.Kafka\Propulsion.Kafka.fsproj", "{5F176C54-609B-4D2E-804B-3C1F60ADDAF4}"
 EndProject
+Project("{6EC3EE1D-3C4E-46DD-8F32-0CC8E7565705}") = "Propulsion.Tests", "tests\Propulsion.Tests\Propulsion.Tests.fsproj", "{BBD50DA2-7932-4D24-888D-C168F4788705}"
+EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
 		Debug|Any CPU = Debug|Any CPU
@@ -59,6 +61,10 @@ Global
 		{5F176C54-609B-4D2E-804B-3C1F60ADDAF4}.Debug|Any CPU.Build.0 = Debug|Any CPU
 		{5F176C54-609B-4D2E-804B-3C1F60ADDAF4}.Release|Any CPU.ActiveCfg = Release|Any CPU
 		{5F176C54-609B-4D2E-804B-3C1F60ADDAF4}.Release|Any CPU.Build.0 = Release|Any CPU
+		{BBD50DA2-7932-4D24-888D-C168F4788705}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{BBD50DA2-7932-4D24-888D-C168F4788705}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{BBD50DA2-7932-4D24-888D-C168F4788705}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{BBD50DA2-7932-4D24-888D-C168F4788705}.Release|Any CPU.Build.0 = Release|Any CPU
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE
@@ -68,6 +74,7 @@ Global
 		{76802BE3-00C2-4B1D-96A2-95A3E2136DBE} = {4670F7C4-A4FD-4E3F-B97C-99F9B3FC1898}
 		{0F72360F-1C14-46E3-9A60-B6BF87BD726D} = {4670F7C4-A4FD-4E3F-B97C-99F9B3FC1898}
 		{5F176C54-609B-4D2E-804B-3C1F60ADDAF4} = {4670F7C4-A4FD-4E3F-B97C-99F9B3FC1898}
+		{BBD50DA2-7932-4D24-888D-C168F4788705} = {302B09C4-7F38-4CF7-93B9-1B7A6035386E}
 	EndGlobalSection
 	GlobalSection(ExtensibilityGlobals) = postSolution
 		SolutionGuid = {DF04AF73-7412-46E5-9CC8-15CB48E3139A}

--- a/build.proj
+++ b/build.proj
@@ -22,6 +22,7 @@
 
   <Target Name="VSTest">
     <Exec Command="dotnet test tests/Jet.ConfluentKafka.FSharp.Integration $(Cfg) $(TestOptions)" />
+    <Exec Command="dotnet test tests/Propulsion.Tests $(Cfg) $(TestOptions)" />
   </Target>
 
   <Target Name="Build" DependsOnTargets="Pack;VSTest" />

--- a/src/Propulsion.Kafka/Producers.fs
+++ b/src/Propulsion.Kafka/Producers.fs
@@ -1,0 +1,31 @@
+﻿namespace Propulsion.Kafka
+
+open Confluent.Kafka
+open Jet.ConfluentKafka.FSharp
+open Serilog
+open System
+
+type StreamsProducer =
+    static member Start(log : ILogger, maxReadAhead, maxConcurrentStreams, clientId, broker, topic, render, categorize, ?statsInterval, ?stateInterval)
+            : Propulsion.ProjectorPipeline<_> =
+        let statsInterval, stateInterval = defaultArg statsInterval (TimeSpan.FromMinutes 5.), defaultArg stateInterval (TimeSpan.FromMinutes 5.)
+        let projectionAndKafkaStats = Propulsion.Streams.Projector.Stats(log.ForContext<Propulsion.Streams.Projector.Stats>(), categorize, statsInterval, stateInterval)
+        let producerConfig = KafkaProducerConfig.Create(clientId, broker, Acks.Leader, compression = CompressionType.Lz4, maxInFlight = 1_000_000, linger = TimeSpan.Zero)
+        let producer = KafkaProducer.Create(log, producerConfig, topic)
+        let attemptWrite (_writePos,stream,fullBuffer : Propulsion.Streams.StreamSpan<_>) = async {
+            let maxEvents, maxBytes = 16384, 1_000_000 - (*fudge*)4096
+            let ((eventCount,_) as stats), span = Propulsion.Streams.Buffering.Span.slice (maxEvents,maxBytes) fullBuffer
+            let spanJson = render (stream, span)
+            try let! _res = producer.ProduceAsync(stream,spanJson)
+                let res = ()
+                return Choice1Of2 (span.index + int64 eventCount,stats,res)
+            with e -> return Choice2Of2 (stats,e) }
+        let interpretWriteResultProgress _streams _stream = function
+            | Choice1Of2 (i',_, _) -> Some i'
+            | Choice2Of2 (_,_) -> None
+        let dispatcher = Propulsion.Streams.Scheduling.Dispatcher<_>(maxConcurrentStreams)
+        let streamScheduler =
+            Propulsion.Streams.Scheduling.StreamSchedulingEngine<_,_>(
+                dispatcher, projectionAndKafkaStats, attemptWrite, interpretWriteResultProgress,
+                fun s l -> s.Dump(l, Propulsion.Streams.Buffering.StreamState.eventsSize, categorize))
+        Propulsion.Streams.Projector.StreamsProjectorPipeline.Start(log, dispatcher.Pump(), streamScheduler.Pump, maxReadAhead, streamScheduler.Submit, statsInterval)

--- a/src/Propulsion.Kafka/Propulsion.Kafka.fsproj
+++ b/src/Propulsion.Kafka/Propulsion.Kafka.fsproj
@@ -13,6 +13,7 @@
   <ItemGroup>
     <Compile Include="Infrastructure.fs" />
     <Compile Include="Consumers.fs" />
+    <Compile Include="Producers.fs" />
   </ItemGroup>
 
   <ItemGroup>

--- a/src/Propulsion/Infrastructure.fs
+++ b/src/Propulsion/Infrastructure.fs
@@ -7,6 +7,9 @@ open System.Threading.Tasks
 module Array =
     let takeWhile p = Seq.takeWhile p >> Array.ofSeq
     let head = Seq.head
+
+module Option = 
+    let toNullable option = match option with None -> System.Nullable() | Some v -> System.Nullable(v)
 #endif
 
 [<AutoOpen>]

--- a/src/Propulsion/Ingestion.fs
+++ b/src/Propulsion/Ingestion.fs
@@ -1,0 +1,157 @@
+﻿module Propulsion.Ingestion
+
+open Serilog
+open System
+open System.Collections.Concurrent
+open System.Threading
+
+/// Manages writing of progress
+/// - Each write attempt is always of the newest token (each update is assumed to also count for all preceding ones)
+/// - retries until success or a new item is posted
+type ProgressWriter<'Res when 'Res: equality>(?period,?sleep) =
+    let sleepSpan = defaultArg sleep (TimeSpan.FromMilliseconds 100.)
+    let writeInterval,sleepPeriod = defaultArg period (TimeSpan.FromSeconds 5.), int sleepSpan.TotalMilliseconds
+    let due = intervalCheck writeInterval
+    let mutable committedEpoch = None
+    let mutable validatedPos = None
+    let result = Event<Choice<'Res,exn>>()
+    [<CLIEvent>] member __.Result = result.Publish
+    member __.Post(version,f) =
+        Volatile.Write(&validatedPos,Some (version,f))
+    member __.CommittedEpoch = Volatile.Read(&committedEpoch)
+    member __.Pump() = async {
+        let! ct = Async.CancellationToken
+        while not ct.IsCancellationRequested do
+            match Volatile.Read &validatedPos with
+            | Some (v,f) when Volatile.Read(&committedEpoch) <> Some v && due () ->
+                try do! f
+                    Volatile.Write(&committedEpoch, Some v)
+                    result.Trigger (Choice1Of2 v)
+                with e -> result.Trigger (Choice2Of2 e)
+            | _ -> do! Async.Sleep sleepPeriod }
+
+[<NoComparison; NoEquality>]        
+type private InternalMessage =
+    /// Confirmed completion of a batch
+    | Validated of epoch: int64
+    /// Result from updating of Progress to backing store - processed up to nominated `epoch` or threw `exn`
+    | ProgressResult of Choice<int64,exn>
+    /// Internal message for stats purposes
+    | Added of streams: int * events: int
+
+type private Stats(log : ILogger, statsInterval : TimeSpan) =
+    let mutable validatedEpoch, comittedEpoch : int64 option * int64 option = None, None
+    let progCommitFails, progCommits = ref 0, ref 0 
+    let cycles, batchesPended, streamsPended, eventsPended = ref 0, ref 0, ref 0, ref 0
+    let statsDue = intervalCheck statsInterval
+    let dumpStats (activeReads, maxReads) =
+        log.Information("Buffering Cycles {cycles} Ingested {batches} ({streams:n0}s {events:n0}e)", !cycles, !batchesPended, !streamsPended, !eventsPended)
+        cycles := 0; batchesPended := 0; streamsPended := 0; eventsPended := 0
+        if !progCommitFails <> 0 || !progCommits <> 0 then
+            match comittedEpoch with
+            | None ->
+                log.Error("Uncommitted {activeReads}/{maxReads} @ {validated}; writing failing: {failures} failures ({commits} successful commits)",
+                        activeReads, maxReads, Option.toNullable validatedEpoch, !progCommitFails, !progCommits)
+            | Some committed when !progCommitFails <> 0 ->
+                log.Warning("Uncommitted {activeReads}/{maxReads} @ {validated} (committed: {committed}, {commits} commits, {failures} failures)",
+                        activeReads, maxReads, Option.toNullable validatedEpoch, committed, !progCommits, !progCommitFails)
+            | Some committed ->
+                log.Information("Uncommitted {activeReads}/{maxReads} @ {validated} (committed: {committed}, {commits} commits)",
+                        activeReads, maxReads, Option.toNullable validatedEpoch, committed, !progCommits)
+            progCommits := 0; progCommitFails := 0
+        else
+            log.Information("Uncommitted {activeReads}/{maxReads} @ {validated} (committed: {committed})",
+                    activeReads, maxReads, Option.toNullable validatedEpoch, Option.toNullable comittedEpoch)
+    member __.Handle : InternalMessage -> unit = function
+        | Validated epoch ->
+            validatedEpoch <- Some epoch
+        | ProgressResult (Choice1Of2 epoch) ->
+            incr progCommits
+            comittedEpoch <- Some epoch
+        | ProgressResult (Choice2Of2 (_exn : exn)) ->
+            incr progCommitFails
+        | Added (streams,events) ->
+            incr batchesPended
+            streamsPended := !streamsPended + streams
+            eventsPended := !eventsPended + events
+    member __.TryDump(readState) =
+        incr cycles
+        let due = statsDue ()
+        if due then dumpStats readState
+        due
+
+type Sem(max) =
+    let inner = new SemaphoreSlim(max)
+    member __.Await(ct : CancellationToken) = inner.WaitAsync(ct) |> Async.AwaitTaskCorrect
+    member __.Release() = inner.Release() |> ignore
+    member __.State = max-inner.CurrentCount,max
+
+/// Buffers items read from a range, unpacking them out of band from the reading so that can overlap
+/// On completion of the unpacking, they get submitted onward to the Submitter which will buffer them for us
+type Ingester<'Items,'Batch> private
+    (   log : ILogger, stats : Stats, maxRead, sleepInterval : TimeSpan,
+        makeBatch : (unit->unit) -> 'Items -> ('Batch * (int * int)),
+        submit : 'Batch -> unit,
+        cts : CancellationTokenSource) =
+    let sleepInterval = int sleepInterval.TotalMilliseconds
+    let maxRead = Sem maxRead
+    let incoming = new ConcurrentQueue<_>()
+    let messages = new ConcurrentQueue<InternalMessage>()
+    let tryDequeue (x : ConcurrentQueue<_>) =
+        let mutable tmp = Unchecked.defaultof<_>
+        if x.TryDequeue &tmp then Some tmp
+        else None
+    let progressWriter = ProgressWriter<_>()
+    let rec tryIncoming () =
+        match tryDequeue incoming with
+        | None -> false
+        | Some (epoch,checkpoint,items) ->
+            let markCompleted () =
+                maxRead.Release()
+                messages.Enqueue (Validated epoch)
+                progressWriter.Post(epoch,checkpoint)
+            let batch,(streamCount, itemCount) = makeBatch markCompleted items
+            submit batch
+            messages.Enqueue(Added (streamCount,itemCount))
+            true
+    let rec tryHandle () =
+        match tryDequeue messages with
+        | None -> false
+        | Some x ->
+            stats.Handle x
+            true
+
+    member private __.Pump() = async {
+        let! ct = Async.CancellationToken
+        use _ = progressWriter.Result.Subscribe(ProgressResult >> messages.Enqueue)
+        Async.Start(progressWriter.Pump(), ct)
+        while not ct.IsCancellationRequested do
+            // arguably the impl should be submitting while unpacking but
+            // - maintaining consistency between incoming order and submit order is required
+            // - in general maxRead will be double maxSubmit so this will only be relevant in catchup situations
+            try let worked = tryHandle () || tryIncoming () || stats.TryDump(maxRead.State)
+                if not worked then do! Async.Sleep sleepInterval
+            with e -> log.Error(e, "Ingester exception") }
+        
+    /// Starts an independent Task which handles
+    /// a) `unpack`ing of `incoming` items
+    /// b) `submit`ting them onward (assuming there is capacity within the `readLimit`)
+    static member Start<'Item>(log, maxRead, makeBatch, submit, ?statsInterval, ?sleepInterval) =
+        let maxWait, statsInterval = defaultArg sleepInterval (TimeSpan.FromMilliseconds 5.), defaultArg statsInterval (TimeSpan.FromMinutes 5.)
+        let cts = new CancellationTokenSource()
+        let stats = Stats(log, statsInterval)
+        let instance = Ingester<_,_>(log, stats, maxRead, maxWait, makeBatch, submit, cts)
+        Async.Start(instance.Pump(), cts.Token)
+        instance
+
+    /// Submits a batch as read for unpacking and submission; will only return after the in-flight reads drops below the limit
+    /// Returns (reads in flight,maximum reads in flight)
+    member __.Submit(epoch, checkpoint, items) = async {
+        // If we've read it, feed it into the queue for unpacking
+        incoming.Enqueue (epoch, checkpoint, items)
+        // ... but we might hold off on yielding if we're at capacity
+        do! maxRead.Await(cts.Token)
+        return maxRead.State }
+
+    /// As range assignments get revoked, a user is expected to `Stop `the active processing thread for the Ingester before releasing references to it
+    member __.Stop() = cts.Cancel() 

--- a/src/Propulsion/Projector.fs
+++ b/src/Propulsion/Projector.fs
@@ -1,0 +1,55 @@
+﻿namespace Propulsion
+
+open Serilog
+open System
+open System.Threading
+open System.Threading.Tasks
+
+type ProjectorPipeline<'Ingester> private (task : Task<unit>, triggerStop, startIngester) =
+
+    interface IDisposable with member __.Dispose() = __.Stop()
+
+    member __.StartIngester(rangeLog : ILogger) : 'Ingester = startIngester rangeLog
+
+    /// Inspects current status of processing task
+    member __.Status = task.Status
+    /// After AwaitCompletion, can be used to infer whether exit was clean
+    member __.RanToCompletion = task.Status = TaskStatus.RanToCompletion 
+
+    /// Request cancellation of processing
+    member __.Stop() = triggerStop ()
+
+    /// Asynchronously awaits until consumer stops or a `handle` invocation yields a fault
+    member __.AwaitCompletion() = Async.AwaitTaskCorrect task
+
+    static member Start(log : Serilog.ILogger, pumpDispatcher, pumpScheduler, pumpSubmitter, startIngester) =
+        let cts = new CancellationTokenSource()
+        let ct = cts.Token
+        let tcs = new TaskCompletionSource<unit>()
+        let start name f =
+            let wrap (name : string) computation = async {
+                try do! computation
+                    log.Information("Exiting {name}", name)
+                with e -> log.Fatal(e, "Abend from {name}", name) }
+            Async.Start(wrap name f, ct)
+        // if scheduler encounters a faulted handler, we propagate that as the consumer's Result
+        let abend (exns : AggregateException) =
+            if tcs.TrySetException(exns) then log.Warning(exns, "Cancelling processing due to {count} faulted handlers", exns.InnerExceptions.Count)
+            else log.Information("Failed setting {count} exceptions", exns.InnerExceptions.Count)
+            // NB cancel needs to be after TSE or the Register(TSE) will win
+            cts.Cancel()
+        let machine = async {
+            // external cancellation should yield a success result
+            use _ = ct.Register(fun _ -> tcs.TrySetResult () |> ignore)
+            start "dispatcher" <| pumpDispatcher
+            // ... fault results from dispatched tasks result in the `machine` concluding with an exception
+            start "scheduler" <| pumpScheduler abend
+            start "submitter" <| pumpSubmitter
+
+            // await for either handler-driven abend or external cancellation via Stop()
+            do! Async.AwaitTaskCorrect tcs.Task }
+        let task = Async.StartAsTask machine
+        let triggerStop () =
+            log.Information("Stopping")
+            cts.Cancel();  
+        new ProjectorPipeline<_>(task, triggerStop, startIngester)

--- a/src/Propulsion/Propulsion.fsproj
+++ b/src/Propulsion/Propulsion.fsproj
@@ -13,7 +13,11 @@
   <ItemGroup>
     <Compile Include="Infrastructure.fs" />
     <Compile Include="Propulsion.fs" />
+    <Compile Include="Ingestion.fs" />
+    <Compile Include="Projector.fs" />
     <Compile Include="Parallel.fs" />
+    <Compile Include="Parallel.fs" />
+    <Compile Include="Streams.fs" />
   </ItemGroup>
 
   <ItemGroup>

--- a/src/Propulsion/Streams.fs
+++ b/src/Propulsion/Streams.fs
@@ -1,0 +1,629 @@
+﻿namespace Propulsion.Streams
+
+open Propulsion
+open Serilog
+open System
+open System.Collections.Concurrent
+open System.Collections.Generic
+open System.Diagnostics
+open System.Threading
+
+/// An Event from a Stream
+type IEvent<'Format> =
+    /// The Event Type, used to drive deserialization
+    abstract member EventType : string
+    /// Event body, as UTF-8 encoded json ready to be injected into the Store
+    abstract member Data : 'Format
+    /// Optional metadata (null, or same as Data, not written if missing)
+    abstract member Meta : 'Format
+    /// The Event's Creation Time (as defined by the writer, i.e. in a mirror, this is intended to reflect the original time)
+    abstract member Timestamp : System.DateTimeOffset
+
+/// A Single Event from an Ordered stream
+[<NoComparison; NoEquality>]
+type StreamItem<'Format> = { stream: string; index: int64; event: IEvent<'Format> }
+
+/// Span of events from a Stream
+[<NoComparison; NoEquality>]
+type StreamSpan<'Format> = { index: int64; events: IEvent<'Format>[] }
+
+[<AutoOpen>]
+module Internal =
+    /// NB FINAL RESTING PLACE TBD
+    type EventData<'Format> =
+        { eventType : string; data : 'Format; meta : 'Format; timestamp: DateTimeOffset }
+        interface IEvent<'Format> with
+            member __.EventType = __.eventType
+            member __.Data = __.data
+            member __.Meta = __.meta
+            member __.Timestamp = __.timestamp
+
+    /// NB FINAL RESTING PLACE TBD
+    type EventData =
+        static member Create(eventType, data, ?meta, ?timestamp) =
+            {   eventType = eventType
+                data = data
+                meta = defaultArg meta null
+                timestamp = match timestamp with Some ts -> ts | None -> DateTimeOffset.UtcNow }
+
+[<AutoOpen>]
+module private Impl =
+    let (|NNA|) xs = if obj.ReferenceEquals(null,xs) then Array.empty else xs
+    let inline arrayBytes (x: _ []) = if obj.ReferenceEquals(null,x) then 0 else x.Length
+    let inline eventSize (x : IEvent<byte[]>) = arrayBytes x.Data + arrayBytes x.Meta + x.EventType.Length + 16
+    let inline mb x = float x / 1024. / 1024.
+    let inline accStopwatch (f : unit -> 't) at =
+        let sw = Stopwatch.StartNew()
+        let r = f ()
+        at sw.Elapsed
+        r
+    /// Gathers stats relating to how many items of a given category have been observed
+    type CatStats() =
+        let cats = Dictionary<string,int64>()
+        member __.Ingest(cat,?weight) = 
+            let weight = defaultArg weight 1L
+            match cats.TryGetValue cat with
+            | true, catCount -> cats.[cat] <- catCount + weight
+            | false, _ -> cats.[cat] <- weight
+        member __.Any = cats.Count <> 0
+        member __.Clear() = cats.Clear()
+        member __.StatsDescending = cats |> Seq.sortBy (fun x -> -x.Value) |> Seq.map (|KeyValue|)
+
+#nowarn "52" // see tmp.Sort
+
+module Progress =
+
+    type [<NoComparison; NoEquality>] internal BatchState = { markCompleted: unit -> unit; streamToRequiredIndex : Dictionary<string,int64> }
+
+    type ProgressState<'Pos>() =
+        let pending = Queue<_>()
+        let trim () =
+            while pending.Count <> 0 && pending.Peek().streamToRequiredIndex.Count = 0 do
+                let batch = pending.Dequeue()
+                batch.markCompleted()
+        member __.AppendBatch(markCompleted, reqs : Dictionary<string,int64>) =
+            pending.Enqueue { markCompleted = markCompleted; streamToRequiredIndex = reqs }
+            trim ()
+        member __.MarkStreamProgress(stream, index) =
+            for x in pending do
+                match x.streamToRequiredIndex.TryGetValue stream with
+                | true, requiredIndex when requiredIndex <= index -> x.streamToRequiredIndex.Remove stream |> ignore
+                | _, _ -> ()
+            trim ()
+        member __.InScheduledOrder getStreamWeight =
+            trim ()
+            let streams = HashSet()
+            let tmp = ResizeArray(16384)
+            let mutable batch = 0
+            for x in pending do
+                batch <- batch + 1
+                for s in x.streamToRequiredIndex.Keys do
+                    if streams.Add s then
+                        tmp.Add((s,(batch,-getStreamWeight s)))
+            let c = Comparer<_>.Default
+            tmp.Sort(fun (_,_a) ((_,_b)) -> c.Compare(_a,_b))
+            tmp |> Seq.map (fun ((s,_)) -> s)
+
+module Buffering =
+
+    module Span =
+        let (|End|) (x : StreamSpan<_>) = x.index + if x.events = null then 0L else x.events.LongLength
+        let dropBeforeIndex min : StreamSpan<_> -> StreamSpan<_> = function
+            | x when x.index >= min -> x // don't adjust if min not within
+            | End n when n < min -> { index = min; events = [||] } // throw away if before min
+#if NET461
+            | x -> { index = min; events = x.events |> Seq.skip (min - x.index |> int) |> Seq.toArray }
+#else
+            | x -> { index = min; events = x.events |> Array.skip (min - x.index |> int) }  // slice
+#endif
+        let merge min (xs : StreamSpan<_> seq) =
+            let xs =
+                seq { for x in xs -> { x with events = (|NNA|) x.events } }
+                |> Seq.map (dropBeforeIndex min)
+                |> Seq.filter (fun x -> x.events.Length <> 0)
+                |> Seq.sortBy (fun x -> x.index)
+            let buffer = ResizeArray()
+            let mutable curr = None
+            for x in xs do
+                match curr, x with
+                // Not overlapping, no data buffered -> buffer
+                | None, _ ->
+                    curr <- Some x
+                // Gap
+                | Some (End nextIndex as c), x when x.index > nextIndex ->
+                    buffer.Add c
+                    curr <- Some x
+                // Overlapping, join
+                | Some (End nextIndex as c), x  ->
+                    curr <- Some { c with events = Array.append c.events (dropBeforeIndex nextIndex x).events }
+            curr |> Option.iter buffer.Add
+            if buffer.Count = 0 then null else buffer.ToArray()
+        let inline estimateBytesAsJsonUtf8 (x: IEvent<'Format[]>) = arrayBytes x.Data + arrayBytes x.Meta + (x.EventType.Length * 2) + 96
+        let slice (maxEvents,maxBytes) streamSpan =
+            let mutable count,bytes = 0, 0
+            let mutable countBudget, bytesBudget = maxEvents,maxBytes
+            let withinLimits y =
+                countBudget <- countBudget - 1
+                let eventBytes = estimateBytesAsJsonUtf8 y
+                bytesBudget <- bytesBudget - eventBytes
+                // always send at least one event in order to surface the problem and have the stream marked malformed
+                let res = count = 0 || (countBudget >= 0 && bytesBudget >= 0)
+                if res then count <- count + 1; bytes <- bytes + eventBytes
+                res
+            let trimmed = { streamSpan with events = streamSpan.events |> Array.takeWhile withinLimits }
+            let stats = trimmed.events.Length, trimmed.events |> Seq.sumBy estimateBytesAsJsonUtf8
+            stats, trimmed
+    [<NoComparison; NoEquality>] 
+    type StreamState<'Format> = { isMalformed: bool; write: int64 option; queue: StreamSpan<'Format>[] } with
+        member __.IsEmpty = obj.ReferenceEquals(null, __.queue)
+        member __.HasValid = not __.IsEmpty && not __.isMalformed
+        member __.IsReady =
+            if not __.HasValid then false else
+
+            match __.write, Array.head __.queue with
+            | Some w, { index = i } -> i = w
+            | None, _ -> true
+    module StreamState =
+        let eventsSize (x : StreamState<byte[]>) =
+            let mutable acc = 0
+            for x in x.queue do
+                for x in x.events do
+                    acc <- acc + eventSize x
+            int64 acc
+        let inline private optionCombine f (r1: 'a option) (r2: 'a option) =
+            match r1, r2 with
+            | Some x, Some y -> f x y |> Some
+            | None, None -> None
+            | None, x | x, None -> x
+        let combine (s1: StreamState<_>) (s2: StreamState<_>) : StreamState<_> =
+            let writePos = optionCombine max s1.write s2.write
+            let items = let (NNA q1, NNA q2) = s1.queue, s2.queue in Seq.append q1 q2
+            { write = writePos; queue = Span.merge (defaultArg writePos 0L) items; isMalformed = s1.isMalformed || s2.isMalformed }
+
+    type Streams<'Format>() =
+        let states = Dictionary<string, StreamState<'Format>>()
+        let merge stream (state : StreamState<_>) =
+            match states.TryGetValue stream with
+            | false, _ ->
+                states.Add(stream, state)
+            | true, current ->
+                let updated = StreamState.combine current state
+                states.[stream] <- updated
+
+        member __.Merge(item : StreamItem<'Format>) =
+            merge item.stream { isMalformed = false; write = None; queue = [| { index = item.index; events = [| item.event |] } |] }
+        member private __.States = states
+        member __.Items = states :> seq<KeyValuePair<string,StreamState<'Format>>>
+        member __.Merge(other: Streams<'Format>) =
+            for x in other.States do
+                merge x.Key x.Value
+
+        member __.Dump(log : ILogger, estimateSize, categorize) =
+            let mutable waiting, waitingB = 0, 0L
+            let waitingCats, waitingStreams = CatStats(), CatStats()
+            for KeyValue (stream,state) in states do
+                let sz = estimateSize state
+                waitingCats.Ingest(categorize stream)
+                waitingStreams.Ingest(sprintf "%s@%dx%d" stream (defaultArg state.write 0L) state.queue.[0].events.Length, (sz + 512L) / 1024L)
+                waiting <- waiting + 1
+                waitingB <- waitingB + sz
+            if waiting <> 0 then log.Information(" Streams Waiting {busy:n0}/{busyMb:n1}MB ", waiting, mb waitingB)
+            if waitingCats.Any then log.Information(" Waiting Categories, events {@readyCats}", Seq.truncate 5 waitingCats.StatsDescending)
+            if waitingCats.Any then log.Information(" Waiting Streams, KB {@readyStreams}", Seq.truncate 5 waitingStreams.StatsDescending)
+
+module Scheduling =
+
+    open Buffering
+
+    type StreamStates<'Format>() =
+        let states = Dictionary<string, StreamState<'Format>>()
+        let update stream (state : StreamState<_>) =
+            match states.TryGetValue stream with
+            | false, _ ->
+                states.Add(stream, state)
+                stream, state
+            | true, current ->
+                let updated = StreamState.combine current state
+                states.[stream] <- updated
+                stream, updated
+        let updateWritePos stream isMalformed pos span = update stream { isMalformed = isMalformed; write = pos; queue = span }
+        let markCompleted stream index = updateWritePos stream false (Some index) null |> ignore
+        let merge (buffer : Streams<_>) =
+            for x in buffer.Items do
+                update x.Key x.Value |> ignore
+
+        let busy = HashSet<string>()
+        let pending trySlipstreamed (requestedOrder : string seq) : seq<int64 option*string*StreamSpan<_>> = seq {
+            let proposed = HashSet()
+            for s in requestedOrder do
+                let state = states.[s]
+                if state.HasValid && not (busy.Contains s) then
+                    proposed.Add s |> ignore
+                    yield state.write, s, Array.head state.queue
+            if trySlipstreamed then
+                // [lazily] Slipstream in further events that are not yet referenced by in-scope batches
+                for KeyValue(s,v) in states do
+                    if v.HasValid && not (busy.Contains s) && proposed.Add s then
+                        yield v.write, s, Array.head v.queue }
+        let markBusy stream = busy.Add stream |> ignore
+        let markNotBusy stream = busy.Remove stream |> ignore
+
+        member __.InternalMerge buffer = merge buffer
+        member __.InternalUpdate stream pos queue = update stream { isMalformed = false; write = Some pos; queue = queue }
+        //member __.Add(stream, index, event, ?isMalformed) =
+        //    updateWritePos stream (defaultArg isMalformed false) None [| { index = index; events = [| event |] } |]
+        //member __.Add(batch: StreamSpan, isMalformed) =
+        //    updateWritePos batch.stream isMalformed None [| { index = batch.span.index; events = batch.span.events } |]
+        member __.SetMalformed(stream,isMalformed) =
+            updateWritePos stream isMalformed None [| { index = 0L; events = null } |]
+        member __.Item(stream) =
+            states.[stream]
+        member __.MarkBusy stream =
+            markBusy stream
+        member __.MarkCompleted(stream, index) =
+            markNotBusy stream
+            markCompleted stream index
+        member __.MarkFailed stream =
+            markNotBusy stream
+        member __.Pending(trySlipstreamed, byQueuedPriority : string seq) : (int64 option * string * StreamSpan<'Format>) seq =
+            pending trySlipstreamed byQueuedPriority
+        member __.Dump(log : ILogger, estimateSize, categorize) =
+            let mutable busyCount, busyB, ready, readyB, unprefixed, unprefixedB, malformed, malformedB, synced = 0, 0L, 0, 0L, 0, 0L, 0, 0L, 0
+            let busyCats, readyCats, readyStreams, unprefixedStreams, malformedStreams = CatStats(), CatStats(), CatStats(), CatStats(), CatStats()
+            let kb sz = (sz + 512L) / 1024L
+            for KeyValue (stream,state) in states do
+                match estimateSize state with
+                | 0L ->
+                    synced <- synced + 1
+                | sz when busy.Contains stream ->
+                    busyCats.Ingest(categorize stream)
+                    busyCount <- busyCount + 1
+                    busyB <- busyB + sz
+                | sz when state.isMalformed ->
+                    malformedStreams.Ingest(stream, mb sz |> int64)
+                    malformed <- malformed + 1
+                    malformedB <- malformedB + sz
+                | sz when not state.IsReady ->
+                    unprefixedStreams.Ingest(stream, mb sz |> int64)
+                    unprefixed <- unprefixed + 1
+                    unprefixedB <- unprefixedB + sz
+                | sz ->
+                    readyCats.Ingest(categorize stream)
+                    readyStreams.Ingest(sprintf "%s@%dx%d" stream (defaultArg state.write 0L) state.queue.[0].events.Length, kb sz)
+                    ready <- ready + 1
+                    readyB <- readyB + sz
+            log.Information("Streams Synced {synced:n0} Active {busy:n0}/{busyMb:n1}MB Ready {ready:n0}/{readyMb:n1}MB Waiting {waiting}/{waitingMb:n1}MB Malformed {malformed}/{malformedMb:n1}MB",
+                synced, busyCount, mb busyB, ready, mb readyB, unprefixed, mb unprefixedB, malformed, mb malformedB)
+            if busyCats.Any then log.Information(" Active Categories, events {@busyCats}", Seq.truncate 5 busyCats.StatsDescending)
+            if readyCats.Any then log.Information(" Ready Categories, events {@readyCats}", Seq.truncate 5 readyCats.StatsDescending)
+            if readyCats.Any then log.Information(" Ready Streams, KB {@readyStreams}", Seq.truncate 5 readyStreams.StatsDescending)
+            if unprefixedStreams.Any then log.Information(" Waiting Streams, KB {@missingStreams}", Seq.truncate 3 unprefixedStreams.StatsDescending)
+            if malformedStreams.Any then log.Information(" Malformed Streams, MB {@malformedStreams}", malformedStreams.StatsDescending)
+
+    /// Messages used internally by projector, including synthetic ones for the purposes of the `Stats` listeners
+    [<NoComparison; NoEquality>]
+    type InternalMessage<'R> =
+        /// Stats per submitted batch for stats listeners to aggregate
+        | Added of streams: int * skip: int * events: int
+        /// Result of processing on stream - result (with basic stats) or the `exn` encountered
+        | Result of stream: string * outcome: 'R
+       
+    type BufferState = Idle | Busy | Full | Slipstreaming
+    /// Gathers stats pertaining to the core projection/ingestion activity
+    type Stats<'R,'E>(log : ILogger, statsInterval : TimeSpan, stateInterval : TimeSpan) =
+        let states, fullCycles, cycles, resultCompleted, resultExn = CatStats(), ref 0, ref 0, ref 0, ref 0
+        let batchesPended, streamsPended, eventsSkipped, eventsPended = ref 0, ref 0, ref 0, ref 0
+        let statsDue, stateDue = intervalCheck statsInterval, intervalCheck stateInterval
+        let mutable dt,ft,it,st,mt = TimeSpan.Zero, TimeSpan.Zero, TimeSpan.Zero, TimeSpan.Zero, TimeSpan.Zero
+        let dumpStats (dispatchActive,dispatchMax) batchesWaiting =
+            log.Information("Scheduler {cycles} cycles ({fullCycles} full) {@states} Running {busy}/{processors} Completed {completed} Exceptions {exns}",
+                !cycles, !fullCycles, states.StatsDescending, dispatchActive, dispatchMax, !resultCompleted, !resultExn)
+            cycles := 0; fullCycles := 0; states.Clear(); resultCompleted := 0; resultExn:= 0
+            log.Information(" Batches Holding {batchesWaiting} Started {batches} ({streams:n0}s {events:n0}-{skipped:n0}e)",
+                batchesWaiting, !batchesPended, !streamsPended, !eventsSkipped + !eventsPended, !eventsSkipped)
+            batchesPended := 0; streamsPended := 0; eventsSkipped := 0; eventsPended := 0
+            log.Information(" Cpu Streams {mt:n1}s Batches {it:n1}s Dispatch {ft:n1}s Results {dt:n1}s Stats {st:n1}s",
+                mt.TotalSeconds, it.TotalSeconds, ft.TotalSeconds, dt.TotalSeconds, st.TotalSeconds)
+            dt <- TimeSpan.Zero; ft <- TimeSpan.Zero; it <- TimeSpan.Zero; st <- TimeSpan.Zero; mt <- TimeSpan.Zero
+        abstract member Handle : InternalMessage<Choice<'R,'E>> -> unit
+        default __.Handle msg = msg |> function
+            | Added (streams, skipped, events) ->
+                incr batchesPended
+                streamsPended := !streamsPended + streams
+                eventsPended := !eventsPended + events
+                eventsSkipped := !eventsSkipped + skipped
+            | Result (_stream, Choice1Of2 _) ->
+                incr resultCompleted
+            | Result (_stream, Choice2Of2 _) ->
+                incr resultExn
+        member __.DumpStats((used,max), batchesWaiting) =
+            incr cycles
+            if statsDue () then
+                dumpStats (used,max) batchesWaiting
+                __.DumpExtraStats()
+        member __.TryDumpState(state,dump,(_dt,_ft,_mt,_it,_st)) =
+            dt <- dt + _dt
+            ft <- ft + _ft
+            mt <- mt + _mt
+            it <- it + _it
+            st <- st + _st
+            incr fullCycles
+            states.Ingest(string state)
+            
+            let due = stateDue ()
+            if due then
+                dump log
+            due
+        /// Allows an ingester or projector to wire in custom stats (typically based on data gathered in a `Handle` override)
+        abstract DumpExtraStats : unit -> unit
+        default __.DumpExtraStats () = ()
+
+    type Sem(max) =
+        let inner = new SemaphoreSlim(max)
+        member __.TryTake() = inner.Wait 0
+        member __.HasCapacity = inner.CurrentCount <> 0
+        member __.Release() = inner.Release() |> ignore
+        member __.State = max-inner.CurrentCount,max
+
+    /// Coordinates the dispatching of work and emission of results, subject to the maxDop concurrent processors constraint
+    type Dispatcher<'R>(maxDop) =
+        // Using a Queue as a) the ordering is more correct, favoring more important work b) we are adding from many threads so no value in ConcurrentBag'sthread-affinity
+        let work = new BlockingCollection<_>(ConcurrentQueue<_>()) 
+        let result = Event<'R>()
+        let dop = Sem maxDop
+        let dispatch work = async {
+            let! res = work
+            result.Trigger res
+            dop.Release() } 
+        [<CLIEvent>] member __.Result = result.Publish
+        member __.HasCapacity = dop.HasCapacity
+        member __.State = dop.State
+        member __.TryAdd(item) =
+            if dop.TryTake() then
+                work.Add(item)
+                true
+            else false
+        member __.Pump () = async {
+            let! ct = Async.CancellationToken
+            for item in work.GetConsumingEnumerable ct do
+                Async.Start(dispatch item) }
+
+    [<NoComparison; NoEquality>]
+    type StreamsBatch<'Format> private (onCompletion, buffer, reqs) =
+        let mutable buffer = Some buffer
+        static member Create(onCompletion, items : StreamItem<'Format> seq) =
+            let buffer, reqs = Buffering.Streams<'Format>(), Dictionary<string,int64>()
+            let mutable itemCount = 0
+            for item in items do
+                itemCount <- itemCount + 1
+                buffer.Merge(item)
+                match reqs.TryGetValue(item.stream), item.index + 1L with
+                | (false, _), required -> reqs.[item.stream] <- required
+                | (true, actual), required when actual < required -> reqs.[item.stream] <- required
+                | (true,_), _ -> () // replayed same or earlier item
+            let batch = StreamsBatch(onCompletion, buffer, reqs)
+            batch,(batch.RemainingStreamsCount,itemCount)
+        member __.OnCompletion = onCompletion
+        member __.Reqs = reqs :> seq<KeyValuePair<string,int64>>
+        member __.RemainingStreamsCount = reqs.Count
+        member __.TryTakeStreams() = let t = buffer in buffer <- None; t
+        member __.TryMerge(other : StreamsBatch<_>) =
+            match buffer, other.TryTakeStreams() with
+            | Some x, Some y -> x.Merge(y); true
+            | Some _, None -> false
+            | None, x -> buffer <- x; false
+
+    /// Consolidates ingested events into streams; coordinates dispatching of these to projector/ingester in the order implied by the submission order
+    /// a) does not itself perform any reading activities
+    /// b) triggers synchronous callbacks as batches complete; writing of progress is managed asynchronously by the TrancheEngine(s)
+    /// c) submits work to the supplied Dispatcher (which it triggers pumping of)
+    /// d) periodically reports state (with hooks for ingestion engines to report same)
+    type StreamSchedulingEngine<'R,'E>
+        (   dispatcher : Dispatcher<_>, stats : Stats<'R,'E>, project : int64 option * string * StreamSpan<byte[]> -> Async<Choice<_,_>>, interpretProgress, dumpStreams,
+            /// Tune number of batches to ingest at a time. Default 4
+            ?maxBatches,
+            /// Opt-in to allowing items to be processed independent of batch sequencing - requires upstream/projection function to be able to identify gaps
+            ?enableSlipstreaming) =
+        let sleepIntervalMs, maxBatches, slipstreamingEnabled = 2, defaultArg maxBatches 4, defaultArg enableSlipstreaming false
+        let work = ConcurrentStack<InternalMessage<Choice<'R,'E>>>() // dont need them ordered so Queue is unwarranted; usage is cross-thread so Bag is not better
+        let pending = ConcurrentQueue<StreamsBatch<byte[]>>() // Queue as need ordering
+        let streams = StreamStates<byte[]>()
+        let progressState = Progress.ProgressState()
+        
+        let weight stream =
+            let state = streams.Item stream
+            let firstSpan = Array.head state.queue
+            let mutable acc = 0
+            for x in firstSpan.events do acc <- acc + eventSize x
+            int64 acc
+
+        // ingest information to be gleaned from processing the results into `streams`
+        static let workLocalBuffer = Array.zeroCreate 1024
+        let tryDrainResults feedStats =
+            let mutable worked, more = false, true
+            while more do
+                let c = work.TryPopRange(workLocalBuffer)
+                if c = 0 (*&& work.IsEmpty*) then
+                    more <- false
+                else worked <- true
+                for i in 0..c-1 do
+                    let x = workLocalBuffer.[i]
+                    match x with
+                    | Added _ -> () // Only processed in Stats (and actually never enters this queue)
+                    | Result (stream,res) ->
+                        match interpretProgress streams stream res with
+                        | None -> streams.MarkFailed stream
+                        | Some index ->
+                            progressState.MarkStreamProgress(stream,index)
+                            streams.MarkCompleted(stream,index)
+                    feedStats x
+            worked
+        // On each iteration, we try to fill the in-flight queue, taking the oldest and/or heaviest streams first
+        let tryFillDispatcher includeSlipstreamed =
+            let mutable hasCapacity, dispatched = dispatcher.HasCapacity, false
+            if hasCapacity then
+                let potential = streams.Pending(includeSlipstreamed, progressState.InScheduledOrder weight)
+                let xs = potential.GetEnumerator()
+                while xs.MoveNext() && hasCapacity do
+                    let (_,s,_) as item = xs.Current
+                    let succeeded = dispatcher.TryAdd(async { let! r = project item in return s, r })
+                    if succeeded then streams.MarkBusy s
+                    dispatched <- dispatched || succeeded // if we added any request, we'll skip sleeping
+                    hasCapacity <- succeeded
+            hasCapacity, dispatched
+        // Take an incoming batch of events, correlating it against our known stream state to yield a set of remaining work
+        let ingestPendingBatch feedStats (markCompleted, items : seq<KeyValuePair<string,int64>>) = 
+            let inline validVsSkip (streamState : StreamState<_>) required =
+                match streamState.write with
+                | Some cw when cw >= required -> 0, 1
+                | _ -> 1, 0
+            let reqs = Dictionary()
+            let mutable count, skipCount = 0, 0
+            for item in items do
+                let streamState = streams.Item item.Key
+                match validVsSkip streamState item.Value with
+                | 0, skip ->
+                    skipCount <- skipCount + skip
+                | required, _ ->
+                    count <- count + required
+                    reqs.[item.Key] <- item.Value
+            progressState.AppendBatch(markCompleted,reqs)
+            feedStats <| Added (reqs.Count,skipCount,count)
+
+        member __.Pump _abend = async {
+            use _ = dispatcher.Result.Subscribe(Result >> work.Push)
+            let! ct = Async.CancellationToken
+            while not ct.IsCancellationRequested do
+                let mutable idle, dispatcherState, remaining = true, Idle, 16
+                let mutable dt,ft,mt,it,st = TimeSpan.Zero, TimeSpan.Zero, TimeSpan.Zero, TimeSpan.Zero, TimeSpan.Zero
+                while remaining <> 0 do
+                    remaining <- remaining - 1
+                    // 1. propagate write write outcomes to buffer (can mark batches completed etc)
+                    let processedResults = (fun () -> tryDrainResults stats.Handle) |> accStopwatch <| fun x -> dt <- dt + x
+                    // 2. top up provisioning of writers queue
+                    let hasCapacity, dispatched = (fun () -> tryFillDispatcher (dispatcherState = Slipstreaming)) |> accStopwatch <| fun x -> ft <- ft + x
+                    idle <- idle && not processedResults && not dispatched
+                    match dispatcherState with
+                    | Idle when not hasCapacity ->
+                        // If we've achieved full state, spin around the loop to dump stats and ingest reader data
+                        dispatcherState <- Full
+                        remaining <- 0
+                    | Idle when remaining = 0 ->
+                        dispatcherState <- Busy
+                    | Idle -> // need to bring more work into the pool as we can't fill the work queue from what we have
+                        // If we're going to fill the write queue with random work, we should bring all read events into the state first
+                        // If we're going to bring in lots of batches, that's more efficient when the streamwise merges are carried out first
+                        let mutable more, batchesTaken = true, 0
+                        while more do
+                            match pending.TryDequeue() with
+                            | true, batch ->
+                                match batch.TryTakeStreams() with None -> () | Some s -> (fun () -> streams.InternalMerge(s)) |> accStopwatch <| fun t -> mt <- mt + t
+                                (fun () -> ingestPendingBatch stats.Handle (batch.OnCompletion, batch.Reqs)) |> accStopwatch <| fun t -> it <- it + t
+                                batchesTaken <- batchesTaken + 1
+                                more <- batchesTaken < maxBatches
+                            | false,_ when batchesTaken <> 0  ->
+                                more <- false
+                            | false,_ when (*batchesTaken = 0 && *)slipstreamingEnabled ->
+                                dispatcherState <- Slipstreaming
+                                more <- false
+                            | false,_  ->
+                                remaining <- 0
+                                more <- false
+                    | Slipstreaming -> // only do one round of slipstreaming
+                        remaining <- 0
+                    | Busy | Full -> failwith "Not handled here"
+                    // This loop can take a long time; attempt logging of stats per iteration
+                    (fun () -> stats.DumpStats(dispatcher.State,pending.Count)) |> accStopwatch <| fun t -> st <- st + t
+                // 3. Record completion state once per full iteration; dumping streams is expensive so needs to be done infrequently
+                if not (stats.TryDumpState(dispatcherState,dumpStreams streams,(dt,ft,mt,it,st))) && not idle then
+                    // 4. Do a minimal sleep so we don't run completely hot when empty (unless we did something non-trivial)
+                    Thread.Sleep sleepIntervalMs } // Not Async.Sleep so we don't give up the thread
+        member __.Submit(x : StreamsBatch<_>) =
+            pending.Enqueue(x)
+    type StreamSchedulingEngine =
+        static member Create
+            (   dispatcher : Dispatcher<string*Choice<int64,exn>>, stats : Stats<int64,exn>, handle : string*StreamSpan<byte[]> -> Async<int>, dumpStreams,
+                ?maxBatches, ?enableSlipstreaming)
+            : StreamSchedulingEngine<int64,exn> =
+            let project (_maybeWritePos, stream, span) : Async<Choice<int64,exn>> = async {
+                try let! count = handle (stream,span)
+                    return Choice1Of2 (span.index + int64 count)
+                with e -> return Choice2Of2 e }
+            let interpretProgress (_streams : StreamStates<_>) _stream : Choice<int64,exn> -> Option<int64> = function
+                | Choice1Of2 index -> Some index
+                | Choice2Of2 _ -> None
+            StreamSchedulingEngine(dispatcher, stats, project, interpretProgress, dumpStreams, ?maxBatches = maxBatches, ?enableSlipstreaming=enableSlipstreaming)
+
+module Projector =
+
+    type OkResult = int64 * (int*int) * unit
+    type FailResult = (int*int) * exn
+
+    type Stats(log : ILogger, categorize, statsInterval, statesInterval) =
+        inherit Scheduling.Stats<OkResult,FailResult>(log, statsInterval, statesInterval)
+        let okStreams, failStreams, badCats, resultOk, resultExnOther = HashSet(), HashSet(), CatStats(), ref 0, ref 0
+        let mutable okEvents, okBytes, exnEvents, exnBytes = 0, 0L, 0, 0L
+
+        override __.DumpExtraStats() =
+            log.Information("Produced {mb:n0}MB {completed:n0}m {streams:n0}s {events:n0}e ({ok:n0} ok)", mb okBytes, !resultOk, okStreams.Count, okEvents, !resultOk)
+            okStreams.Clear(); resultOk := 0; okEvents <- 0; okBytes <- 0L
+            if !resultExnOther <> 0 then
+                log.Warning("Exceptions {mb:n0}MB {fails:n0}r {streams:n0}s {events:n0}e", mb exnBytes, !resultExnOther, failStreams.Count, exnEvents)
+                resultExnOther := 0; failStreams.Clear(); exnBytes <- 0L; exnEvents <- 0
+                log.Warning("Malformed cats {@badCats}", badCats.StatsDescending)
+                badCats.Clear()
+
+        override __.Handle message =
+            let inline adds x (set:HashSet<_>) = set.Add x |> ignore
+            let inline bads x (set:HashSet<_>) = badCats.Ingest(categorize x); adds x set
+            base.Handle message
+            match message with
+            | Scheduling.Added _ -> () // Processed by standard logging already; we have nothing to add
+            | Scheduling.Result (stream, Choice1Of2 (_,(es,bs),_r)) ->
+                adds stream okStreams
+                okEvents <- okEvents + es
+                okBytes <- okBytes + int64 bs
+                incr resultOk
+            | Scheduling.Result (stream, Choice2Of2 ((es,bs),exn)) ->
+                bads stream failStreams
+                exnEvents <- exnEvents + es
+                exnBytes <- exnBytes + int64 bs
+                incr resultExnOther
+                log.Warning(exn,"Could not write {b:n0} bytes {e:n0}e in stream {stream}", bs, es, stream)
+
+    type StreamsIngester =
+        static member Start(log, maxRead, submit, ?statsInterval, ?sleepInterval) =
+            let makeBatch onCompletion (partitionId,items : StreamItem<_> seq) =
+                let items = Array.ofSeq items
+                let streams = HashSet(seq { for x in items -> x.stream })
+                let batch : Submission.SubmissionBatch<_> = { partitionId = partitionId; onCompletion = onCompletion; messages = items }
+                batch,(streams.Count,items.Length)
+            Ingestion.Ingester<int*StreamItem<_> seq,Submission.SubmissionBatch<StreamItem<_>>>.Start(log, maxRead, makeBatch, submit, ?statsInterval = statsInterval, ?sleepInterval = sleepInterval)
+
+    type StreamsProjectorPipeline =
+        static member Start(log : Serilog.ILogger, pumpDispatcher, pumpScheduler, maxReadAhead, submitStreamsBatch, statsInterval, ?maxSubmissionsPerPartition) =
+            let maxSubmissionsPerPartition = defaultArg maxSubmissionsPerPartition 5
+            let mapBatch onCompletion (x : Submission.SubmissionBatch<StreamItem<_>>) : Scheduling.StreamsBatch<_> =
+                Scheduling.StreamsBatch.Create(onCompletion, x.messages) |> fst
+            let submitBatch (x : Scheduling.StreamsBatch<_>) : int =
+                submitStreamsBatch x
+                x.RemainingStreamsCount
+            let tryCompactQueue (queue : Queue<Scheduling.StreamsBatch<_>>) =
+                let mutable acc, worked = None, false
+                for x in queue do
+                    match acc with
+                    | None -> acc <- Some x
+                    | Some a -> if a.TryMerge x then worked <- true
+                worked
+            let submitter = Submission.SubmissionEngine<_,_>(log, maxSubmissionsPerPartition, mapBatch, submitBatch, statsInterval, tryCompactQueue=tryCompactQueue)
+            let startIngester rangeLog = StreamsIngester.Start(rangeLog, maxReadAhead, submitter.Ingest)
+            ProjectorPipeline.Start(log, pumpDispatcher, pumpScheduler, submitter.Pump(), startIngester)
+
+type StreamsProjector =
+    static member Start(log : ILogger, maxReadAhead, maxConcurrentStreams, project, categorize, ?statsInterval, ?stateInterval)
+            : ProjectorPipeline<_> =
+        let statsInterval, stateInterval = defaultArg statsInterval (TimeSpan.FromMinutes 5.), defaultArg stateInterval (TimeSpan.FromMinutes 5.)
+        let projectionStats = Scheduling.Stats<_,_>(log.ForContext<Scheduling.Stats<_,_>>(), statsInterval, stateInterval)
+        let dispatcher = Scheduling.Dispatcher<_>(maxConcurrentStreams)
+        let streamScheduler = Scheduling.StreamSchedulingEngine.Create(dispatcher, projectionStats, project, fun s l -> s.Dump(l, Buffering.StreamState.eventsSize, categorize))
+        Projector.StreamsProjectorPipeline.Start(log, dispatcher.Pump(), streamScheduler.Pump, maxReadAhead, streamScheduler.Submit, statsInterval)

--- a/tests/Propulsion.Tests/ProgressTests.fs
+++ b/tests/Propulsion.Tests/ProgressTests.fs
@@ -1,0 +1,47 @@
+﻿module ProgressTests
+
+open Propulsion.Streams
+open Swensen.Unquote
+open System.Collections.Generic
+open Xunit
+
+let mkDictionary xs = Dictionary<string,int64>(dict xs)
+
+let [<Fact>] ``Empty has zero streams pending or progress to write`` () =
+    let sut = Progress.ProgressState<_>()
+    let queue = sut.InScheduledOrder(fun _ -> 0L)
+    test <@ Seq.isEmpty queue @>
+
+let [<Fact>] ``Can add multiple batches with overlapping streams`` () =
+    let sut = Progress.ProgressState<_>()
+    let noBatchesComplete () = failwith "No bathes should complete"
+    sut.AppendBatch(noBatchesComplete, mkDictionary ["a",1L; "b",2L])
+    sut.AppendBatch(noBatchesComplete, mkDictionary ["b",2L; "c",3L])
+
+let [<Fact>] ``Marking Progress removes batches and triggers the callbacks`` () =
+    let sut = Progress.ProgressState<_>()
+    let mutable callbacks = 0
+    let complete () = callbacks <- callbacks + 1
+    sut.AppendBatch(complete, mkDictionary ["a",1L; "b",2L])
+    sut.MarkStreamProgress("a",1L) |> ignore
+    sut.MarkStreamProgress("b",3L) |> ignore
+    1 =! callbacks
+
+let [<Fact>] ``Empty batches get removed immediately`` () =
+    let sut = Progress.ProgressState<_>()
+    let mutable callbacks = 0
+    let complete () = callbacks <- callbacks + 1
+    sut.AppendBatch(complete, mkDictionary [||])
+    sut.AppendBatch(complete, mkDictionary [||])
+    2 =! callbacks
+
+let [<Fact>] ``Marking progress is not persistent`` () =
+    let sut = Progress.ProgressState<_>()
+    let mutable callbacks = 0
+    let complete () = callbacks <- callbacks + 1
+    sut.AppendBatch(complete, mkDictionary ["a",1L])
+    sut.MarkStreamProgress("a",2L) |> ignore
+    sut.AppendBatch(complete, mkDictionary ["a",1L; "b",2L])
+    1 =! callbacks
+
+// TODO: lots more coverage of newer functionality - the above were written very early into the exercise

--- a/tests/Propulsion.Tests/Propulsion.Tests.fsproj
+++ b/tests/Propulsion.Tests/Propulsion.Tests.fsproj
@@ -1,0 +1,28 @@
+﻿<Project Sdk="Microsoft.NET.Sdk">
+
+  <PropertyGroup>
+    <TargetFrameworks>netcoreapp2.1;net461</TargetFrameworks>
+    <WarningLevel>5</WarningLevel>
+    <IsPackable>false</IsPackable>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <Compile Include="ProgressTests.fs" />
+    <Compile Include="StreamStateTests.fs" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <ProjectReference Include="..\..\src\Propulsion\Propulsion.fsproj" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="15.9.0" />
+    <PackageReference Include="unquote" Version="4.0" />
+    <PackageReference Include="xunit" Version="2.4.0" />
+    <PackageReference Include="xunit.runner.visualstudio" Version="2.4.0">
+      <PrivateAssets>all</PrivateAssets>
+      <IncludeAssets>runtime; build; native; contentfiles; analyzers</IncludeAssets>
+    </PackageReference>
+  </ItemGroup>
+
+</Project>

--- a/tests/Propulsion.Tests/StreamStateTests.fs
+++ b/tests/Propulsion.Tests/StreamStateTests.fs
@@ -1,0 +1,99 @@
+﻿module StreamStateTests
+
+open Propulsion.Streams
+open Propulsion.Streams.Buffering
+open Swensen.Unquote
+open System
+open Xunit
+
+let canonicalTime = System.DateTimeOffset.UtcNow
+
+/// An Event about to be written, see IEvent for further information
+type EventData<'Format> =
+    { eventType : string; data : 'Format; meta : 'Format; timestamp: DateTimeOffset }
+    interface IEvent<'Format> with
+        member __.EventType = __.eventType
+        member __.Data = __.data
+        member __.Meta = __.meta
+        member __.Timestamp = __.timestamp
+
+type EventData =
+    static member Create(eventType, data, ?meta, ?timestamp) =
+        {   eventType = eventType
+            data = data
+            meta = defaultArg meta null
+            timestamp = match timestamp with Some ts -> ts | None -> DateTimeOffset.UtcNow }
+
+let mk p c : StreamSpan<string> = { index = p; events = [| for x in 0..c-1 -> EventData.Create(p + int64 x |> string, null, timestamp=canonicalTime) |] }
+let mergeSpans = Span.merge
+let trimSpans = Span.dropBeforeIndex
+let is (xs : StreamSpan<string>[]) (res : StreamSpan<string>[]) =
+    (xs,res) ||> Seq.forall2 (fun x y -> x.index = y.index && (x.events,y.events) ||> Seq.forall2 (fun x y -> x.EventType = y.EventType))
+
+let [<Fact>] ``nothing`` () =
+    let r = mergeSpans 0L [ mk 0L 0; mk 0L 0 ]
+    test <@ obj.ReferenceEquals(null,r) @>
+
+let [<Fact>] ``synced`` () =
+    let r = mergeSpans 1L [ mk 0L 1; mk 0L 0 ]
+    test <@ obj.ReferenceEquals(null,r) @>
+
+let [<Fact>] ``no overlap`` () =
+    let r = mergeSpans 0L [ mk 0L 1; mk 2L 2 ]
+    test <@ r |> is [| mk 0L 1; mk 2L 2 |] @>
+
+let [<Fact>] ``overlap`` () =
+    let r = mergeSpans 0L [ mk 0L 1; mk 0L 2 ]
+    test <@ r |> is [| mk 0L 2 |] @>
+
+let [<Fact>] ``remove nulls`` () =
+    let r = mergeSpans 1L [ mk 0L 1; mk 0L 2 ]
+    test <@ r |> is [| mk 1L 1 |] @>
+
+let [<Fact>] ``adjacent`` () =
+    let r = mergeSpans 0L [ mk 0L 1; mk 1L 2 ]
+    test <@ r |> is [| mk 0L 3 |] @>
+
+let [<Fact>] ``adjacent to min`` () =
+    let r = Array.map (trimSpans 2L) [| mk 0L 1; mk 1L 2 |]
+    test <@ r |> is [| mk 2L 0; mk 2L 1 |] @>
+
+let [<Fact>] ``adjacent to min merge`` () =
+    let r = mergeSpans 2L [ mk 0L 1; mk 1L 2 ]
+    test <@ r |> is [| mk 2L 1 |] @>
+
+let [<Fact>] ``adjacent to min no overlap`` () =
+    let r = mergeSpans 2L [ mk 0L 1; mk 2L 1 ]
+    test <@ r |> is [| mk 2L 1|] @>
+
+let [<Fact>] ``adjacent trim`` () =
+    let r = Array.map (trimSpans 1L) [| mk 0L 2; mk 2L 2 |]
+    test <@ r |> is [| mk 1L 1; mk 2L 2 |] @>
+
+let [<Fact>] ``adjacent trim merge`` () =
+    let r = mergeSpans 1L [ mk 0L 2; mk 2L 2 ]
+    test <@ r |> is [| mk 1L 3 |] @>
+
+let [<Fact>] ``adjacent trim append`` () =
+    let r = Array.map (trimSpans 1L) [| mk 0L 2; mk 2L 2; mk 5L 1 |]
+    test <@ r |> is [| mk 1L 1; mk 2L 2; mk 5L 1 |] @>
+
+let [<Fact>] ``adjacent trim append merge`` () =
+    let r = mergeSpans 1L [ mk 0L 2; mk 2L 2; mk 5L 1]
+    test <@ r |> is [| mk 1L 3; mk 5L 1 |] @>
+
+let [<Fact>] ``mixed adjacent trim append`` () =
+    let r = Array.map (trimSpans 1L) [| mk 0L 2; mk 5L 1; mk 2L 2 |]
+    test <@ r |> is [| mk 1L 1; mk 5L 1; mk 2L 2 |] @>
+
+let [<Fact>] ``mixed adjacent trim append merge`` () =
+    let r = mergeSpans 1L [ mk 0L 2; mk 5L 1; mk 2L 2]
+    test <@ r |> is [| mk 1L 3; mk 5L 1 |] @>
+
+let [<Fact>] ``fail`` () =
+    let r = mergeSpans 11614L [ {index=11614L; events=null}; mk 11614L 1 ]
+    test <@ r |> is [| mk 11614L 1 |] @>
+
+let [<Fact>] ``fail 2`` () =
+    let r = mergeSpans 11613L [ mk 11614L 1; {index=11614L; events=null} ]
+    test <@ r |> is [| mk 11614L 1 |] @>


### PR DESCRIPTION
Implements components to enable pipelines that accommodate:
- merging and buffering by stream
- having a separated `Ingester` task to manage the buffering and asynchronous Document parsing necessitated by the push-pull model of the CosmosDb ChangeFeedProcessor
- writing progress asynchronously

The design and implementation is intentionally in line with that used in the `ParallelConsumer`, in order that it can slot into the same `ConsumerPipeline` for Kafka (and similar arrangements for CosmosDb etc)