### PR TITLE
Add ParallelProducer

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,7 +10,8 @@ The `Unreleased` section name is replaced by the expected version of next releas
 
 ### Added
 
-- Add `StreamsConsumer` and `StreamsProducer` [#35](https://github.com/jet/Jet.ConfluentKafka.FSharp/pull/35)
+- `StreamsConsumer` and `StreamsProducer` [#35](https://github.com/jet/Jet.ConfluentKafka.FSharp/pull/35)
+- `ParallelProducer` [#36](https://github.com/jet/Jet.ConfluentKafka.FSharp/pull/36)
 
 ### Changed
 
@@ -33,7 +34,7 @@ The `Unreleased` section name is replaced by the expected version of next releas
 
 ### Fixed
 
-- Singificant tuning / throughput improvements for `ParallelConsumer` 
+- Significant tuning / throughput improvements for `ParallelConsumer` 
 
 <a name="1.0.0-rc11"></a>
 ## [1.0.0-rc11] - 2019-05-27

--- a/src/Propulsion/Propulsion.fsproj
+++ b/src/Propulsion/Propulsion.fsproj
@@ -16,7 +16,6 @@
     <Compile Include="Ingestion.fs" />
     <Compile Include="Projector.fs" />
     <Compile Include="Parallel.fs" />
-    <Compile Include="Parallel.fs" />
     <Compile Include="Streams.fs" />
   </ItemGroup>
 


### PR DESCRIPTION
Caters for cases where one needs:
- Range-driven Ingestion (with async progress checkpointing), e.g. from CosmosDb's ChangeFeedProcessor
- the ability to produce messages to Kafka based on the inputs

But does not need:
- ordering or deduplication as `Streams` based algorithms provide
- Stream-level isolation
- Coalescing of events within a stream