### PR TITLE
Fix MessageMaxBytes defaulting

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,8 @@ The `Unreleased` section name is replaced by the expected version of next releas
 ### Removed
 ### Fixed
 
+- Fixed and clarified defaulting behavior for `fetchMaxBytes`
+
 <a name="1.0.1"></a>
 ## [1.0.1] - 2019-06-10
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,12 +11,12 @@ The `Unreleased` section name is replaced by the expected version of next releas
 ### Added
 ### Changed
 
-- Added `Producing... ` prefix to log messages for conistency
+- Added `Producing... ` prefix to log messages for consistency
 
 ### Removed
 ### Fixed
 
-- Fixed and clarified defaulting behavior for `fetchMaxBytes`
+- Fixed and clarified defaulting behavior for `fetchMaxBytes`,`maxInFlight`,`partitioner` arguments [#40](https://github.com/jet/Jet.ConfluentKafka.FSharp/pull/40)
 
 <a name="1.0.1"></a>
 ## [1.0.1] - 2019-06-10

--- a/src/Jet.ConfluentKafka.FSharp/ConfluentKafka.fs
+++ b/src/Jet.ConfluentKafka.FSharp/ConfluentKafka.fs
@@ -62,10 +62,10 @@ type KafkaProducerConfig private (inner, broker : Uri) =
                 MessageSendMaxRetries = Nullable (defaultArg retries 60), // default 2
                 Acks = Nullable acks,
                 SocketKeepaliveEnable = Nullable (defaultArg socketKeepAlive true), // default: false
-                LogConnectionClose = Nullable false) // https://github.com/confluentinc/confluent-kafka-dotnet/issues/124#issuecomment-289727017
-        maxInFlight |> Option.iter (fun x -> c.MaxInFlight <- Nullable x) // default 1_000_000
+                LogConnectionClose = Nullable false, // https://github.com/confluentinc/confluent-kafka-dotnet/issues/124#issuecomment-289727017
+                MaxInFlight = Nullable (defaultArg maxInFlight 1_000_000)) // default 1_000_000
         linger |> Option.iter<TimeSpan> (fun x -> c.LingerMs <- Nullable (int x.TotalMilliseconds)) // default 0
-        partitioner |> Option.iter (fun x -> c.Partitioner <- x)
+        partitioner |> Option.iter (fun x -> c.Partitioner <- Nullable x)
         compression |> Option.iter (fun x -> c.CompressionType <- Nullable x)
         statisticsInterval |> Option.iter<TimeSpan> (fun x -> c.StatisticsIntervalMs <- Nullable (int x.TotalMilliseconds))
         custom |> Option.iter (fun xs -> for KeyValue (k,v) in xs do c.Set(k,v))


### PR DESCRIPTION
- Update xmldoc, make one piece of defaulting less surprising. Not urgent so no urgency to push unless someone has a reason. (will likely roll in with an update to a newer CK version)
- Fix unintentional `Nullable` for `partitioner`