### PR TITLE
Target Confluent.Kafka 1.2.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,7 +11,8 @@ The `Unreleased` section name is replaced by the expected version of next releas
 ### Added
 ### Changed
 
-- Targeted `MinVer` v `2.0.0-alpha.2`
+- Targets `MinVer` v `2.0.0-alpha.2`
+- Targets `Confluent.Kafka` v `1.2.0`, `librdkafka.redist` v `1.2.0` [#44](https://github.com/jet/Jet.ConfluentKafka.FSharp/pull/44)
 
 ### Removed
 ### Fixed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,11 +9,13 @@ The `Unreleased` section name is replaced by the expected version of next releas
 ## [Unreleased]
 
 ### Added
+
+- `config` argument to `KafakConsumerConfig` and `KafkaProduerConfig` constructors accepting an `IDictionary<string,string>` to match Confluent.Kafka 1.2 ctor overloads [#44](https://github.com/jet/Jet.ConfluentKafka.FSharp/pull/44)
+
 ### Changed
 
-- Targets `MinVer` v `2.0.0-alpha.2`
+- Uses `MinVer` v `2.0.0-alpha.2` internally
 - Targets [`Confluent.Kafka` v `1.2.0`](https://github.com/confluentinc/confluent-kafka-dotnet/releases/tag/v1.2.0), `librdkafka.redist` v `1.2.0` [#44](https://github.com/jet/Jet.ConfluentKafka.FSharp/pull/44)
-- Change `custom` argument to `IDictionary<string,string>` from `seq<KeyValuePair<string,string>>` to match Confluent.Kafka 1.2 ctor overload [#44](https://github.com/jet/Jet.ConfluentKafka.FSharp/pull/44)
 
 ### Removed
 ### Fixed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,7 +12,7 @@ The `Unreleased` section name is replaced by the expected version of next releas
 ### Changed
 
 - Targets `MinVer` v `2.0.0-alpha.2`
-- Targets `Confluent.Kafka` v `1.2.0`, `librdkafka.redist` v `1.2.0` [#44](https://github.com/jet/Jet.ConfluentKafka.FSharp/pull/44)
+- Targets [`Confluent.Kafka` v `1.2.0`](https://github.com/confluentinc/confluent-kafka-dotnet/releases/tag/v1.2.0), `librdkafka.redist` v `1.2.0` [#44](https://github.com/jet/Jet.ConfluentKafka.FSharp/pull/44)
 - Change `custom` argument to `IDictionary<string,string>` from `seq<KeyValuePair<string,string>>` to match Confluent.Kafka 1.2 ctor overload [#44](https://github.com/jet/Jet.ConfluentKafka.FSharp/pull/44)
 
 ### Removed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,7 @@ The `Unreleased` section name is replaced by the expected version of next releas
 
 - Targets `MinVer` v `2.0.0-alpha.2`
 - Targets `Confluent.Kafka` v `1.2.0`, `librdkafka.redist` v `1.2.0` [#44](https://github.com/jet/Jet.ConfluentKafka.FSharp/pull/44)
+- Change `custom` argument to `IDictionary<string,string>` from `seq<KeyValuePair<string,string>>` to match Confluent.Kafka 1.2 ctor overload [#44](https://github.com/jet/Jet.ConfluentKafka.FSharp/pull/44)
 
 ### Removed
 ### Fixed

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # Jet.ConfluentKafka.FSharp [![Build Status](https://dev.azure.com/jet-opensource/opensource/_apis/build/status/jet.Jet.ConfluentKafka.FSharp)](https://dev.azure.com/jet-opensource/opensource/_build/latest?definitionId=7) [![release](https://img.shields.io/github/release/jet/Jet.ConfluentKafka.FSharp.svg)](https://github.com/jet/Jet.ConfluentKafka.FSharp/releases) [![NuGet](https://img.shields.io/nuget/v/Jet.ConfluentKafka.FSharp.svg?logo=nuget)](https://www.nuget.org/packages/Jet.ConfluentKafka.FSharp/) [![license](https://img.shields.io/github/license/jet/Jet.ConfluentKafka.FSharp.svg)](LICENSE) ![code size](https://img.shields.io/github/languages/code-size/jet/Jet.ConfluentKafka.FSharp.svg)
 
-F# friendly wrapper for `Confluent.Kafka` versions `>= 1.1.0`, with minimal dependencies or additional abstractions.
+F# friendly wrapper for `Confluent.Kafka` versions `>= 1.2.0`, with minimal dependencies or additional abstractions.
 
 ## Components
 

--- a/src/Jet.ConfluentKafka.FSharp/ConfluentKafka.fs
+++ b/src/Jet.ConfluentKafka.FSharp/ConfluentKafka.fs
@@ -64,7 +64,7 @@ type KafkaProducerConfig private (inner, broker : Uri) =
                 SocketKeepaliveEnable = Nullable (defaultArg socketKeepAlive true), // default: false
                 LogConnectionClose = Nullable false, // https://github.com/confluentinc/confluent-kafka-dotnet/issues/124#issuecomment-289727017
                 MaxInFlight = Nullable (defaultArg maxInFlight 1_000_000)) // default 1_000_000
-        linger |> Option.iter<TimeSpan> (fun x -> c.LingerMs <- Nullable (int x.TotalMilliseconds)) // default 0
+        linger |> Option.iter<TimeSpan> (fun x -> c.LingerMs <- Nullable x.TotalMilliseconds) // default 0
         partitioner |> Option.iter (fun x -> c.Partitioner <- Nullable x)
         compression |> Option.iter (fun x -> c.CompressionType <- Nullable x)
         statisticsInterval |> Option.iter<TimeSpan> (fun x -> c.StatisticsIntervalMs <- Nullable (int x.TotalMilliseconds))
@@ -150,7 +150,7 @@ type BatchedProducer private (log: ILogger, inner : IProducer<string, string>, t
             /// Having a non-zero linger is critical to items getting into the correct groupings
             /// (even if it of itself does not guarantee anything based on Kafka's guarantees). Default: 100ms
             ?linger: TimeSpan) : BatchedProducer =
-        let lingerMs = match linger with Some x -> int x.TotalMilliseconds | None -> 100
+        let lingerMs = match linger with Some x -> x.TotalMilliseconds | None -> 100.
         log.Information("Producing... Using batch Mode with linger={lingerMs}", lingerMs)
         config.Inner.LingerMs <- Nullable lingerMs
         config.Inner.MaxInFlight <- Nullable (defaultArg maxInFlight 1)

--- a/src/Jet.ConfluentKafka.FSharp/ConfluentKafka.fs
+++ b/src/Jet.ConfluentKafka.FSharp/ConfluentKafka.fs
@@ -51,12 +51,11 @@ type KafkaProducerConfig private (inner, broker : Uri) =
             ?socketKeepAlive,
             /// Partition algorithm. Default: `ConsistentRandom`.
             ?partitioner,
-            /// Miscellaneous configuration parameters to be passed to the underlying Confluent.Kafka producer configuration.
-            ?custom,
-            /// Postprocesses the ProducerConfig after the rest of the rules have been applied
+            /// Miscellaneous configuration parameters to be passed to the underlying Confluent.Kafka producer configuration. Same as constructor argument for Confluent.Kafka >=1.2.
+            ?custom : IDictionary<string,string>,
             ?customize) =
         let c =
-            ProducerConfig(
+            ProducerConfig((match custom with Some x -> x | None -> Dictionary<string,string>() :> IDictionary<string,string>),
                 ClientId = clientId, BootstrapServers = Config.validateBrokerUri broker,
                 RetryBackoffMs = Nullable (match retryBackoff with Some (t : TimeSpan) -> int t.TotalMilliseconds | None -> 1000), // CK default 100ms
                 MessageSendMaxRetries = Nullable (defaultArg retries 60), // default 2
@@ -68,7 +67,6 @@ type KafkaProducerConfig private (inner, broker : Uri) =
         partitioner |> Option.iter (fun x -> c.Partitioner <- Nullable x)
         compression |> Option.iter (fun x -> c.CompressionType <- Nullable x)
         statisticsInterval |> Option.iter<TimeSpan> (fun x -> c.StatisticsIntervalMs <- Nullable (int x.TotalMilliseconds))
-        custom |> Option.iter (fun xs -> for KeyValue (k,v) in xs do c.Set(k,v))
         customize |> Option.iter (fun f -> f c)
         KafkaProducerConfig(c, broker)
 
@@ -206,8 +204,8 @@ type KafkaConsumerConfig = private { inner: ConsumerConfig; topics: string list;
             ?statisticsInterval,
             /// Consumed offsets commit interval. Default 5s.
             ?offsetCommitInterval,
-            /// Misc configuration parameter to be passed to the underlying CK consumer.
-            ?custom,
+            /// Misc configuration parameters to be passed to the underlying CK consumer. (Same as constructor argument for Confluent.Kafka >=1.2.
+            ?custom : IDictionary<string,string>,
             /// Postprocesses the ConsumerConfig after the rest of the rules have been applied
             ?customize,
 
@@ -225,7 +223,7 @@ type KafkaConsumerConfig = private { inner: ConsumerConfig; topics: string list;
         let minInFlightBytes = defaultArg minInFlightBytes (maxInFlightBytes * 2L / 3L)
         let fetchMaxBytes = defaultArg fetchMaxBytes 100_000
         let c =
-            ConsumerConfig(
+            ConsumerConfig((match custom with Some x -> x | None -> Dictionary<string,string>() :> IDictionary<string,string>),
                 ClientId=clientId, BootstrapServers=Config.validateBrokerUri broker, GroupId=groupId,
                 AutoOffsetReset = Nullable (defaultArg autoOffsetReset AutoOffsetReset.Earliest), // default: latest
                 FetchMaxBytes = Nullable fetchMaxBytes, // default: 524_288_000
@@ -236,9 +234,8 @@ type KafkaConsumerConfig = private { inner: ConsumerConfig; topics: string list;
         fetchMinBytes |> Option.iter (fun x -> c.FetchMinBytes <- x) // Fetch waits for this amount of data for up to FetchWaitMaxMs (100)
         offsetCommitInterval |> Option.iter<TimeSpan> (fun x -> c.AutoCommitIntervalMs <- Nullable <| int x.TotalMilliseconds)
         statisticsInterval |> Option.iter<TimeSpan> (fun x -> c.StatisticsIntervalMs <- Nullable <| int x.TotalMilliseconds)
-        custom |> Option.iter<seq<KeyValuePair<string,string>>> (fun xs -> for KeyValue (k,v) in xs do c.Set(k,v))
         customize |> Option.iter<ConsumerConfig -> unit> (fun f -> f c)
-        {   inner = c 
+        {   inner = c
             topics = match Seq.toList topics with [] -> invalidArg "topics" "must be non-empty collection" | ts -> ts
             buffering = {
                 maxBatchDelay = defaultArg maxBatchDelay (TimeSpan.FromMilliseconds 500.); maxBatchSize = defaultArg maxBatchSize 1000

--- a/src/Jet.ConfluentKafka.FSharp/ConfluentKafka.fs
+++ b/src/Jet.ConfluentKafka.FSharp/ConfluentKafka.fs
@@ -55,7 +55,8 @@ type KafkaProducerConfig private (inner, broker : Uri) =
             ?custom : IDictionary<string,string>,
             ?customize) =
         let c =
-            ProducerConfig((match custom with Some x -> x | None -> Dictionary<string,string>() :> IDictionary<string,string>),
+            let customPropsDictionary = match custom with Some x -> x | None -> Dictionary<string,string>() :> IDictionary<string,string>
+            ProducerConfig(customPropsDictionary, // CK 1.2 and later has a default ctor and an IDictionary<string,string> overload
                 ClientId = clientId, BootstrapServers = Config.validateBrokerUri broker,
                 RetryBackoffMs = Nullable (match retryBackoff with Some (t : TimeSpan) -> int t.TotalMilliseconds | None -> 1000), // CK default 100ms
                 MessageSendMaxRetries = Nullable (defaultArg retries 60), // default 2
@@ -223,7 +224,8 @@ type KafkaConsumerConfig = private { inner: ConsumerConfig; topics: string list;
         let minInFlightBytes = defaultArg minInFlightBytes (maxInFlightBytes * 2L / 3L)
         let fetchMaxBytes = defaultArg fetchMaxBytes 100_000
         let c =
-            ConsumerConfig((match custom with Some x -> x | None -> Dictionary<string,string>() :> IDictionary<string,string>),
+            let customPropsDictionary = match custom with Some x -> x | None -> Dictionary<string,string>() :> IDictionary<string,string>
+            ConsumerConfig(customPropsDictionary, // CK 1.2 and later has a default ctor and an IDictionary<string,string> overload
                 ClientId=clientId, BootstrapServers=Config.validateBrokerUri broker, GroupId=groupId,
                 AutoOffsetReset = Nullable (defaultArg autoOffsetReset AutoOffsetReset.Earliest), // default: latest
                 FetchMaxBytes = Nullable fetchMaxBytes, // default: 524_288_000

--- a/src/Jet.ConfluentKafka.FSharp/Jet.ConfluentKafka.FSharp.fsproj
+++ b/src/Jet.ConfluentKafka.FSharp/Jet.ConfluentKafka.FSharp.fsproj
@@ -23,8 +23,8 @@
     <PackageReference Include="FSharp.Core" Version="4.3.4" Condition=" '$(TargetFramework)' != 'net461' " />
 
     <PackageReference Include="Newtonsoft.Json" Version="11.0.2" />
-    <PackageReference Include="Confluent.Kafka" Version="[1.1.0]" />
-    <PackageReference Include="librdkafka.redist" Version="[1.1.0]" />
+    <PackageReference Include="Confluent.Kafka" Version="[1.2.0]" />
+    <PackageReference Include="librdkafka.redist" Version="[1.2.0]" />
     <PackageReference Include="Serilog" Version="2.7.1" />
   </ItemGroup>
 


### PR DESCRIPTION
- [x] handles one minor change in underlying CK API (change from int -> float) - surface API does not change
- [x] Adds a `config` optional arg on config ctors to align with [CK API's new `IDictionayr<string,string>` overload](https://github.com/confluentinc/confluent-kafka-dotnet/releases/tag/v1.2.0)