### PR TITLE
infra/issue-98-dotnet-version-matrix

### DIFF
--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -26,24 +26,24 @@ jobs:
   strategy:
     maxParallel: 2
     matrix:
-      Stable_Global:
-        _dotnetConfig: 'global'
-      Preview_Net10:
-        _dotnetConfig: 'net10'
+      GlobalJson:
+        dotnetGlobalJson: true
+      Net10:
+        dotnetGlobalJson: false
+        dotnetVersion: '10.x'
   steps:
     - task: UseDotNet@2
       displayName: 'Install .NET SDK (global.json)'
-      condition: eq(variables['_dotnetConfig'], 'global')
+      condition: eq(variables['dotnetGlobalJson'], 'true')
       inputs:
         packageType: sdk
         useGlobalJson: true
     - task: UseDotNet@2
-      displayName: 'Install .NET 10 SDK'
-      condition: eq(variables['_dotnetConfig'], 'net10')
+      displayName: 'Install .NET SDK'
+      condition: eq(variables['dotnetGlobalJson'], 'false')
       inputs:
         packageType: sdk
-        version: '10.x'
-        includePreviewVersions: true
+        version: $(dotnetVersion)
     - script: |
         docker network create kafka-net
         docker run -d --name zookeeper --network kafka-net --publish 2181:2181 zookeeper:3.4

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -6,19 +6,19 @@ name: $(Rev:r)
 #	MacOS: Builds only
 
 jobs:
-# - job: Windows
-#   pool:
-#     vmImage: 'windows-latest'
-#   steps:
-#   - script: dotnet pack build.proj
-#     displayName: dotnet pack build.proj
-#     env:
-#       BUILD_PR: $(SYSTEM.PULLREQUEST.PULLREQUESTNUMBER)
-#       BUILD_ID: $(BUILD.BUILDNUMBER)
-#   - task: PublishBuildArtifacts@1
-#     inputs:
-#       pathtoPublish: 'bin'
-#       artifactName: 'nupkgs'
+- job: Windows
+  pool:
+    vmImage: 'windows-latest'
+  steps:
+  - script: dotnet pack build.proj
+    displayName: dotnet pack build.proj
+    env:
+      BUILD_PR: $(SYSTEM.PULLREQUEST.PULLREQUESTNUMBER)
+      BUILD_ID: $(BUILD.BUILDNUMBER)
+  - task: PublishBuildArtifacts@1
+    inputs:
+      pathtoPublish: 'bin'
+      artifactName: 'nupkgs'
 
 - job: Linux
   pool:
@@ -63,14 +63,21 @@ jobs:
         testResultsFiles: 'tests/**/*.trx'
       condition: succeededOrFailed()
 
-# - job: MacOS
-#   pool:
-#     vmImage: 'macOS-latest'
-#   steps:
-#   - task: UseDotNet@2
-#     displayName: 'Install .NET Core sdk'
-#     inputs:
-#       packageType: sdk
-#       useGlobalJson: true
-#   - script: dotnet pack build.proj
-#     displayName: dotnet pack build.proj
+- job: MacOS
+  pool:
+    vmImage: 'macOS-latest'
+  steps:
+  - task: UseDotNet@2
+    displayName: 'Install .NET SDK (global.json)'
+    condition: eq(variables['dotnetGlobalJson'], 'true')
+    inputs:
+      packageType: sdk
+      useGlobalJson: true
+  - task: UseDotNet@2
+    displayName: 'Install .NET SDK'
+    condition: eq(variables['dotnetGlobalJson'], 'false')
+    inputs:
+      packageType: sdk
+      version: $(dotnetVersion)
+  - script: dotnet pack build.proj
+    displayName: dotnet pack build.proj

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -23,45 +23,35 @@ jobs:
 - job: Linux
   pool:
     vmImage: 'ubuntu-latest'
-  strategy:
-    maxParallel: 2
-    matrix:
-      GlobalJson:
-        dotnetGlobalJson: true
-      Net10:
-        dotnetGlobalJson: false
-        dotnetVersion: '10.x'
   steps:
-    - task: UseDotNet@2
-      displayName: 'Install .NET SDK (global.json)'
-      condition: eq(variables['dotnetGlobalJson'], 'true')
-      inputs:
-        packageType: sdk
-        useGlobalJson: true
-    - task: UseDotNet@2
-      displayName: 'Install .NET SDK'
-      condition: eq(variables['dotnetGlobalJson'], 'false')
-      inputs:
-        packageType: sdk
-        version: $(dotnetVersion)
-    - script: |
-        docker network create kafka-net
-        docker run -d --name zookeeper --network kafka-net --publish 2181:2181 zookeeper:3.4
-        docker run -d --name kafka --network kafka-net --hostname localhost --publish 9092:9092 \
-            --env KAFKA_ADVERTISED_HOST_NAME=127.0.0.1 --env ZOOKEEPER_IP=zookeeper \
-            --env KAFKA_AUTO_CREATE_TOPICS_ENABLE=true \
-            ches/kafka
-        sleep 15
-      displayName: Docker kafka for integration tests
-    - script: dotnet test build.proj -v d
-      displayName: Run Integration tests
-      env:
-        TEST_KAFKA_BROKER: localhost:9092
-    - task: PublishTestResults@2
-      inputs:
-        testResultsFormat: 'VSTest'
-        testResultsFiles: 'tests/**/*.trx'
-      condition: succeededOrFailed()
+  - task: UseDotNet@2
+    displayName: 'Install .NET SDK (global.json)'
+    inputs:
+      packageType: sdk
+      useGlobalJson: true
+  - task: UseDotNet@2
+    displayName: 'Install .NET SDK 10.x'
+    inputs:
+      packageType: sdk
+      version: 10.x
+  - script: |
+      docker network create kafka-net
+      docker run -d --name zookeeper --network kafka-net --publish 2181:2181 zookeeper:3.4
+      docker run -d --name kafka --network kafka-net --hostname localhost --publish 9092:9092 \
+          --env KAFKA_ADVERTISED_HOST_NAME=127.0.0.1 --env ZOOKEEPER_IP=zookeeper \
+          --env KAFKA_AUTO_CREATE_TOPICS_ENABLE=true \
+          ches/kafka
+      sleep 15
+    displayName: Docker kafka for integration tests
+  - script: dotnet test build.proj -v d
+    displayName: Run Integration tests
+    env:
+      TEST_KAFKA_BROKER: localhost:9092
+  - task: PublishTestResults@2
+    inputs:
+      testResultsFormat: 'VSTest'
+      testResultsFiles: 'tests/**/*.trx'
+    condition: succeededOrFailed()
 
 - job: MacOS
   pool:
@@ -69,15 +59,13 @@ jobs:
   steps:
   - task: UseDotNet@2
     displayName: 'Install .NET SDK (global.json)'
-    condition: eq(variables['dotnetGlobalJson'], 'true')
     inputs:
       packageType: sdk
       useGlobalJson: true
   - task: UseDotNet@2
-    displayName: 'Install .NET SDK'
-    condition: eq(variables['dotnetGlobalJson'], 'false')
+    displayName: 'Install .NET SDK 10.x'
     inputs:
       packageType: sdk
-      version: $(dotnetVersion)
+      version: 10.x
   - script: dotnet pack build.proj
     displayName: dotnet pack build.proj

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -6,24 +6,44 @@ name: $(Rev:r)
 #	MacOS: Builds only
 
 jobs:
-- job: Windows
-  pool:
-    vmImage: 'windows-latest'
-  steps:
-  - script: dotnet pack build.proj
-    displayName: dotnet pack build.proj
-    env:
-      BUILD_PR: $(SYSTEM.PULLREQUEST.PULLREQUESTNUMBER)
-      BUILD_ID: $(BUILD.BUILDNUMBER)
-  - task: PublishBuildArtifacts@1
-    inputs:
-      pathtoPublish: 'bin'
-      artifactName: 'nupkgs'
+# - job: Windows
+#   pool:
+#     vmImage: 'windows-latest'
+#   steps:
+#   - script: dotnet pack build.proj
+#     displayName: dotnet pack build.proj
+#     env:
+#       BUILD_PR: $(SYSTEM.PULLREQUEST.PULLREQUESTNUMBER)
+#       BUILD_ID: $(BUILD.BUILDNUMBER)
+#   - task: PublishBuildArtifacts@1
+#     inputs:
+#       pathtoPublish: 'bin'
+#       artifactName: 'nupkgs'
 
 - job: Linux
   pool:
     vmImage: 'ubuntu-latest'
+  strategy:
+    maxParallel: 2
+    matrix:
+      Stable_Global:
+        _dotnetConfig: 'global'
+      Preview_Net10:
+        _dotnetConfig: 'net10'
   steps:
+    - task: UseDotNet@2
+      displayName: 'Install .NET SDK (global.json)'
+      condition: eq(variables['_dotnetConfig'], 'global')
+      inputs:
+        packageType: sdk
+        useGlobalJson: true
+    - task: UseDotNet@2
+      displayName: 'Install .NET 10 SDK'
+      condition: eq(variables['_dotnetConfig'], 'net10')
+      inputs:
+        packageType: sdk
+        version: '10.x'
+        includePreviewVersions: true
     - script: |
         docker network create kafka-net
         docker run -d --name zookeeper --network kafka-net --publish 2181:2181 zookeeper:3.4
@@ -43,14 +63,14 @@ jobs:
         testResultsFiles: 'tests/**/*.trx'
       condition: succeededOrFailed()
 
-- job: MacOS
-  pool:
-    vmImage: 'macOS-latest'
-  steps:
-  - task: UseDotNet@2
-    displayName: 'Install .NET Core sdk'
-    inputs:
-      packageType: sdk
-      useGlobalJson: true
-  - script: dotnet pack build.proj
-    displayName: dotnet pack build.proj
+# - job: MacOS
+#   pool:
+#     vmImage: 'macOS-latest'
+#   steps:
+#   - task: UseDotNet@2
+#     displayName: 'Install .NET Core sdk'
+#     inputs:
+#       packageType: sdk
+#       useGlobalJson: true
+#   - script: dotnet pack build.proj
+#     displayName: dotnet pack build.proj

--- a/tests/FsKafka.Integration/FsKafka.Integration.fsproj
+++ b/tests/FsKafka.Integration/FsKafka.Integration.fsproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>net8.0</TargetFramework>
+    <TargetFrameworks>net8.0;net10.0</TargetFrameworks>
   </PropertyGroup>
 
   <ItemGroup>


### PR DESCRIPTION
The PR expands testing to cover .NET 10.

Specifically:

 - Makes the test project target multiple frameworks: `net8.0` and `net10.0`
 - Installs two .NET SDK versions in CI:
     1. The version in `global.json` (currently `8.0.100`)
     2. .NET `10.x`

Closes https://github.com/jet/FsKafka/issues/98