### PR TITLE
infra/issue-97-confluent-kafka-test-matrix

### DIFF
--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -23,6 +23,14 @@ jobs:
 - job: Linux
   pool:
     vmImage: 'ubuntu-latest'
+  strategy:
+    matrix:
+      CK_1_9_2:
+        ConfluentKafkaVersion: '1.9.2'
+        LibrdkafkaRedistVersion: '1.9.2'
+      CK_2_14_0:
+        ConfluentKafkaVersion: '2.14.0'
+        LibrdkafkaRedistVersion: '2.14.0'
   steps:
   - task: UseDotNet@2
     displayName: 'Install .NET SDK (global.json)'
@@ -43,7 +51,7 @@ jobs:
           ches/kafka
       sleep 15
     displayName: Docker kafka for integration tests
-  - script: dotnet test build.proj -v d
+  - script: dotnet test build.proj -v d /p:ConfluentKafkaVersion=$(ConfluentKafkaVersion) /p:LibrdkafkaRedistVersion=$(LibrdkafkaRedistVersion)
     displayName: Run Integration tests
     env:
       TEST_KAFKA_BROKER: localhost:9092

--- a/src/FsKafka/FsKafka.fsproj
+++ b/src/FsKafka/FsKafka.fsproj
@@ -2,6 +2,8 @@
 
   <PropertyGroup>
     <TargetFramework>netstandard2.0</TargetFramework>
+    <ConfluentKafkaVersion Condition="'$(ConfluentKafkaVersion)' == ''">1.9.2</ConfluentKafkaVersion>
+    <LibrdkafkaRedistVersion Condition="'$(LibrdkafkaRedistVersion)' == ''">$(ConfluentKafkaVersion)</LibrdkafkaRedistVersion>
   </PropertyGroup>
 
   <ItemGroup>
@@ -16,8 +18,8 @@
     <PackageReference Include="FSharp.Core" Version="4.3.4" />
 
     <PackageReference Include="Newtonsoft.Json" Version="13.0.1" />
-    <PackageReference Include="Confluent.Kafka" Version="[1.9.2]" />
-    <PackageReference Include="librdkafka.redist" Version="[1.9.2]" />
+    <PackageReference Include="Confluent.Kafka" Version="[$(ConfluentKafkaVersion)]" />
+    <PackageReference Include="librdkafka.redist" Version="[$(LibrdkafkaRedistVersion)]" />
     <PackageReference Include="Serilog" Version="2.7.1" />
   </ItemGroup>
 


### PR DESCRIPTION
Adds test matrix for `Confluent.Kafka` versions `1.9.2` (current default), `2.14.0` (latest as of writing). 

First step towards https://github.com/jet/FsKafka/issues/97