### PR TITLE
Allow `Confluent.Kafka` up to `2.15.0`

### DIFF
--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -28,9 +28,9 @@ jobs:
       CK_1_9_2:
         ConfluentKafkaVersion: '1.9.2'
         LibrdkafkaRedistVersion: '1.9.2'
-      CK_2_14_0:
-        ConfluentKafkaVersion: '2.14.0'
-        LibrdkafkaRedistVersion: '2.14.0'
+      CK_2_15_0:
+        ConfluentKafkaVersion: '2.15.0'
+        LibrdkafkaRedistVersion: '2.15.0'
   steps:
   - task: UseDotNet@2
     displayName: 'Install .NET SDK (global.json)'

--- a/src/FsKafka/FsKafka.fsproj
+++ b/src/FsKafka/FsKafka.fsproj
@@ -18,8 +18,8 @@
     <PackageReference Include="FSharp.Core" Version="4.3.4" />
 
     <PackageReference Include="Newtonsoft.Json" Version="13.0.1" />
-    <PackageReference Include="Confluent.Kafka" Version="[$(ConfluentKafkaVersion),2.15.0]" />
-    <PackageReference Include="librdkafka.redist" Version="[$(LibrdkafkaRedistVersion),2.15.0]" />
+    <PackageReference Include="Confluent.Kafka" Version="[$(ConfluentKafkaVersion),3.0.0)" />
+    <PackageReference Include="librdkafka.redist" Version="[$(LibrdkafkaRedistVersion),3.0.0)" />
     <PackageReference Include="Serilog" Version="2.7.1" />
   </ItemGroup>
 

--- a/src/FsKafka/FsKafka.fsproj
+++ b/src/FsKafka/FsKafka.fsproj
@@ -18,8 +18,8 @@
     <PackageReference Include="FSharp.Core" Version="4.3.4" />
 
     <PackageReference Include="Newtonsoft.Json" Version="13.0.1" />
-    <PackageReference Include="Confluent.Kafka" Version="[$(ConfluentKafkaVersion)]" />
-    <PackageReference Include="librdkafka.redist" Version="[$(LibrdkafkaRedistVersion)]" />
+    <PackageReference Include="Confluent.Kafka" Version="[$(ConfluentKafkaVersion),2.15.0]" />
+    <PackageReference Include="librdkafka.redist" Version="[$(LibrdkafkaRedistVersion),2.15.0]" />
     <PackageReference Include="Serilog" Version="2.7.1" />
   </ItemGroup>
 


### PR DESCRIPTION
This PR allows later `Confluent.Kafka` versions - up to `2.15.0`.

The default resolution is still the baseline `1.9.2`. 

Relates to https://github.com/jet/FsKafka/issues/97